### PR TITLE
add gem release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release to RubyGems
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New Version"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - rc
+
+env:
+  RUBY_VERSION: 3.1.3
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: git-actions/set-user@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - name: Bump version and release
+        run: |
+             bundle config unset deployment
+             bundle exec gem bump -v ${{ inputs.version }} -m "v%{version}" --file lib/openhab/dsl/version.rb
+             bundle check
+             git add Gemfile.lock
+             git commit --amend --no-edit
+             GEM_HOST_API_KEY=${{ secrets.GEM_HOST_API_KEY }} bin/rake release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    openhab-jrubyscripting (5.0.0.rc12)
+    openhab-jrubyscripting (5.0.0.rc.12)
       bundler (~> 2.2)
       marcel (~> 1.0)
       method_source (~> 1.0)
@@ -59,6 +59,7 @@ GEM
     ffi (1.15.5)
     ffi (1.15.5-java)
     formatador (1.1.0)
+    gem-release (2.2.2)
     gene_pool (1.5.0)
       concurrent-ruby (>= 1.0)
     guard (2.18.0)
@@ -207,6 +208,7 @@ DEPENDENCIES
   commonmarker
   cucumber (~> 8.0)
   cuke_linter (~> 1.2)
+  gem-release (~> 2.2)
   guard-rubocop (~> 1.5)
   guard-shell (~> 0.7)
   guard-yard (~> 2.2)

--- a/lib/openhab/dsl/version.rb
+++ b/lib/openhab/dsl/version.rb
@@ -4,6 +4,6 @@ module OpenHAB
   module DSL
     # Version of openHAB helper libraries
     # @return [String]
-    VERSION = "5.0.0.rc12"
+    VERSION = "5.0.0.rc.12"
   end
 end

--- a/openhab-jrubyscripting.gemspec
+++ b/openhab-jrubyscripting.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "cucumber", "~> 8.0"
   spec.add_development_dependency "cuke_linter", "~> 1.2"
+  spec.add_development_dependency "gem-release", "~> 2.2"
   spec.add_development_dependency "guard-rubocop", "~> 1.5"
   spec.add_development_dependency "guard-shell", "~> 0.7"
   spec.add_development_dependency "guard-yard", "~> 2.2"


### PR DESCRIPTION
this has been tested in my own repo at https://github.com/ccutrer/openhab-jruby/actions/runs/4226468917/jobs/7339936590, resulting in commit https://github.com/ccutrer/openhab-jruby/commit/f13bbe7b60c211b85b49c52b6731815321ddc522 and gem https://rubygems.org/gems/openhab-jrubyscripting/versions/5.0.0.rc.13

it's manually triggered for now, you just get to specify how much to bump the gem version