### PR TITLE
fix nested reentrant timer

### DIFF
--- a/lib/openhab/dsl/timer_manager.rb
+++ b/lib/openhab/dsl/timer_manager.rb
@@ -55,8 +55,7 @@ module OpenHAB
       # @!visibility private
       def delete(timer)
         logger.trace("Removing #{timer} from timers")
-        @timers.remove(timer)
-        return unless timer.id
+        return unless @timers.remove(timer) && timer.id
 
         @timers_by_id.remove(timer.id)
       end


### PR DESCRIPTION
Fix a bug where a nested reentrant timer would continue to execute even after the timer has been cancelled by its id.
