### PR TITLE
fix #reschedule on timers with id after it has terminated

### DIFF
--- a/lib/openhab/dsl/timer_manager.rb
+++ b/lib/openhab/dsl/timer_manager.rb
@@ -79,7 +79,13 @@ module OpenHAB
       end
 
       #
-      # Reschedule a single timer by id
+      # Reschedule a single timer by id.
+      #
+      # @note Only timers that are still active can be rescheduled by their id.
+      #   Once a timer is finished executing or cancelled, it is no longer maintained by TimerManager,
+      #   and calling this method will do nothing.
+      #   To reschedule a possibly expired or cancelled timer, either call the {Core::Timer#reschedule}
+      #   method of the timer object, or use {schedule}.
       #
       # @param [Object] id
       # @param [java.time.temporal.TemporalAmount, #to_zoned_date_time, Proc, nil] duration
@@ -139,7 +145,7 @@ module OpenHAB
                   "Do not schedule a new timer with an ID inside a #schedule block"
           end
 
-          if timer&.cancelled?
+          if new_timer&.cancelled?
             new_timer = nil
           elsif new_timer.nil? && timer && !timer.cancelled?
             timer.cancel!

--- a/lib/openhab/rspec/mocks/timer.rb
+++ b/lib/openhab/rspec/mocks/timer.rb
@@ -79,10 +79,10 @@ module OpenHAB
           @id = id
           @block = block
           @thread_locals = thread_locals
-          reschedule(time)
+          reschedule!(time)
         end
 
-        def reschedule(time = nil)
+        def reschedule!(time = nil)
           Thread.current[:openhab_rescheduled_timer] = true if Thread.current[:openhab_rescheduled_timer] == self
           @execution_time = new_execution_time(time || @time)
           @executed = false

--- a/spec/openhab/core/timer_spec.rb
+++ b/spec/openhab/core/timer_spec.rb
@@ -174,19 +174,6 @@ RSpec.describe OpenHAB::Core::Timer do
         expect(timers).not_to include("id")
       end
 
-      it "does not remove the timer if it was rescheduled" do
-        expect(timers).to receive(:delete).once.and_call_original
-        executed = 0
-        after(0.1.seconds, id: "id") do |t|
-          executed += 1
-          t.reschedule if executed == 1
-        end
-
-        time_travel_and_execute_timers(0.4.seconds)
-        time_travel_and_execute_timers(0.2.seconds)
-        expect(executed).to be 2
-      end
-
       it "can reschedule a timer by id" do
         timer1 = after(5.seconds, id: "id") { nil }
         timer2 = timers.reschedule("id", 1.second)
@@ -229,6 +216,78 @@ RSpec.describe OpenHAB::Core::Timer do
 
         time_travel_and_execute_timers(0.2.seconds)
         expect(result).to eq 3
+      end
+
+      describe "#reschedule" do
+        it "works" do
+          executed = 0
+          timer = after(100.ms, id: :mytimer) { executed += 1 }
+          time_travel_and_execute_timers(70.ms)
+          timer.reschedule
+          time_travel_and_execute_timers(80.ms)
+          expect(executed).to eq 0
+          time_travel_and_execute_timers(70.ms)
+          expect(executed).to eq 1
+        end
+
+        it "works inside the execution block" do
+          expect(timers).to receive(:delete).once.and_call_original
+          executed = 0
+          after(100.ms, id: "id") do |t|
+            executed += 1
+            t.reschedule if executed == 1
+          end
+
+          time_travel_and_execute_timers(150.ms)
+          time_travel_and_execute_timers(150.ms)
+          expect(executed).to be 2
+        end
+
+        it "works on a finished timer" do
+          executions = 0
+          timer1 = after(100.ms, id: :mytimer) { executions += 1 }
+
+          expect(timers).to include(:mytimer)
+          time_travel_and_execute_timers(150.ms)
+          expect(executions).to eq 1
+          expect(timers).not_to include(:mytimer)
+
+          timer1.reschedule
+
+          expect(timers).to include(:mytimer)
+          time_travel_and_execute_timers(150.ms)
+          expect(executions).to eq 2
+        end
+
+        it "works on a cancelled timer" do
+          executions = 0
+          timer1 = after(100.ms, id: :mytimer) { executions += 1 }
+
+          expect(timers).to include(:mytimer)
+
+          timer1.cancel
+
+          time_travel_and_execute_timers(150.ms)
+          expect(executions).to eq 0
+          expect(timers).not_to include(:mytimer)
+
+          timer1.reschedule
+
+          expect(timers).to include(:mytimer)
+          time_travel_and_execute_timers(150.ms)
+          expect(executions).to eq 1
+        end
+
+        it "cancels other timers with the same id" do
+          executed = []
+          timer1 = after(100.ms, id: :mytimer) { executed << 1 }
+          after(100.ms, id: :mytimer) { executed << 2 }
+
+          timer1.reschedule
+
+          time_travel_and_execute_timers(150.ms)
+          expect(executed).to match_array([1])
+        end
       end
 
       describe "TimerManager#schedule" do


### PR DESCRIPTION
Timers#reschedule worked on timers without id, the same way openHAB's timers do, but it didn't work when the timer had an id. This PR fixed this problem.

