### PR TITLE
fix Audio.play_sound with volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # JRuby openHAB Scripting Change Log
 
+## [5.0.1](https://github.com/openhab/openhab-jruby/compare/v5.0.0...main)
+
+### Bug Fixes
+
+- Fix an error when calling Audio.play_sound specifying the volume but not the sink.
+
 ## [5.0.0](https://github.com/openhab/openhab-jruby/compare/4.45.2...v5.0.0)
 
 5.0 is the first release as the officially supported gem of the openHAB organization.

--- a/lib/openhab/core/actions/audio.rb
+++ b/lib/openhab/core/actions/audio.rb
@@ -23,7 +23,14 @@ module OpenHAB
           #
           def play_sound(filename, sink: nil, volume: nil)
             volume = PercentType.new(volume) unless volume.is_a?(PercentType) || volume.nil?
-            playSound(sink&.to_s, filename.to_s, volume)
+            # JRuby calls the wrong overloaded method when volume is given, but sink is nil
+            # will call playSound(String, String, float) instead of playSound(String, String, PercentType)
+            # and end up with argument type mismatched. So we need to give it a bit of help here.
+            if sink
+              playSound(sink.to_s, filename.to_s, volume)
+            else
+              playSound(filename.to_s, volume)
+            end
           end
 
           #


### PR DESCRIPTION
I'm not sure where this issue lies. 

I'm not sure if this is a bug in 9.4.2.0 that surfaced because Audio.playSound recently got a new overloaded method?

So two overloaded java methods with the same number of parameters, but different signatures.

I am calling the java method with `Audio.playSound(nil, "soundfile", PercentType.new(100))`

It is supposed to call this: https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/audio#playSound(java.lang.String,java.lang.String,org.openhab.core.library.types.PercentType)

but instead I got an error indicating that it's trying to call this

https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/audio#playSound(java.lang.String,java.lang.String,float)

This is the error/exception from my log:
`for method Audio.playSound expected [java.lang.String,java.lang.String,float]; got: [null,java.lang.String,org.openhab.core.library.types.PercentType]; error: null (TypeError)`

When I call the method with a String as the first argument, it would work fine.

So this PR is a workaround to help jruby/java find the correct method.

