### PR TITLE
remove jruby9.3 from oh4 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
             java_version: 17
           - openhab_version: 4.0.0-SNAPSHOT
             java_version: 11
+          - openhab_version: 4.0.0-SNAPSHOT
+            jruby_version: "jruby-9.3.10.0"
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The addon is set to 9.4 https://github.com/openhab/openhab-addons/pull/14556