### PR TITLE
Fix DSL.provider doc

### DIFF
--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -777,7 +777,7 @@ module OpenHAB
     # Sets the implicit provider(s) for operations inside the block.
     #
     # @param (see #provider!)
-    # @yield [] The block will be executed in the context of the specified unit(s).
+    # @yield [] The block will be executed using the specified provider(s).
     # @return [Object] the result of the block
     #
     # @example
@@ -793,11 +793,11 @@ module OpenHAB
     # @see provider!
     # @see OpenHAB::Core::Provider.current Provider.current for how the current provider is calculated
     #
-    def provider(*args, **kwargs)
+    def provider(*providers, **providers_by_type)
       raise ArgumentError, "You must give a block to set the provider for the duration of" unless block_given?
 
       begin
-        old_providers = provider!(*args, **kwargs)
+        old_providers = provider!(*providers, **providers_by_type)
         yield
       ensure
         Thread.current[:openhab_providers] = old_providers


### PR DESCRIPTION
I'm not sure what to do regarding the [@overload](https://github.com/openhab/openhab-jruby/compare/main...jimtng:provider-docs?expand=1#diff-f28698d5180c99b407383b3925e5d0d166fed423d20216aa0a0c7d5d41ef34b5R818). It appears that it was planned to have two versions of the method signature but forgot to complete it.