### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,12 @@ jobs:
           ruby -Ilib/openhab/dsl -r version -e 'puts "OLD_VERSION=#{OpenHAB::DSL::VERSION}"' >> $GITHUB_ENV
           bundle exec gem bump -v ${{ inputs.version }} -m "v%{version}" --file lib/openhab/dsl/version.rb
           ruby -Ilib/openhab/dsl -r version -e 'puts "NEW_VERSION=#{OpenHAB::DSL::VERSION}"' >> $GITHUB_ENV
-          git add Gemfile.lock
       - name: Generate CHANGELOG
         env:
           CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bin/rake changelog[${{ env.OLD_VERSION }},${{ env.NEW_VERSION }},tmp/new_changes.md]
-          git add CHANGELOG.md
+          git add Gemfile.lock CHANGELOG.md
       - name: Release Gem
         env:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release to RubyGems
+name: Release a New Version
 
 on:
   workflow_dispatch:
@@ -38,9 +38,9 @@ jobs:
       - name: Bump version
         run: |
           bundle config unset deployment
-          echo 'OLD_VERSION='$(ruby -Ilib/openhab/dsl -r version -e "puts OpenHAB::DSL::VERSION") >> $GITHUB_ENV
+          ruby -Ilib/openhab/dsl -r version -e 'puts "OLD_VERSION=#{OpenHAB::DSL::VERSION}"' >> $GITHUB_ENV
           bundle exec gem bump -v ${{ inputs.version }} -m "v%{version}" --file lib/openhab/dsl/version.rb
-          echo 'NEW_VERSION='$(ruby -Ilib/openhab/dsl -r version -e "puts OpenHAB::DSL::VERSION") >> $GITHUB_ENV
+          ruby -Ilib/openhab/dsl -r version -e 'puts "NEW_VERSION=#{OpenHAB::DSL::VERSION}"' >> $GITHUB_ENV
           git add Gemfile.lock
       - name: Generate CHANGELOG
         env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     faraday-http-cache (2.4.1)
       faraday (>= 0.8)
     faraday-net_http (3.0.2)
+    faraday-retry (2.1.0)
+      faraday (~> 2.0)
     ffi (1.15.5)
     ffi (1.15.5-java)
     fiber-local (1.0.0)
@@ -282,6 +284,7 @@ DEPENDENCIES
   commonmarker
   cucumber (~> 8.0)
   cuke_linter (~> 1.2)
+  faraday-retry (~> 2.1)
   gem-release (~> 2.2)
   github_changelog_generator (~> 1.16)
   guard-rubocop (~> 1.5)

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "cucumber", "~> 8.0"
   spec.add_development_dependency "cuke_linter", "~> 1.2"
+  spec.add_development_dependency "faraday-retry", "~> 2.1"
   spec.add_development_dependency "gem-release", "~> 2.2"
   spec.add_development_dependency "github_changelog_generator", "~> 1.16"
   spec.add_development_dependency "guard-rubocop", "~> 1.5"


### PR DESCRIPTION
I'm not really sure what the problem is with the generator. It appeared to be intermittent, and faraday-retry might help.

It seems that the `rake changelog` caused some changes in Gemfile.lock, so it needed to be staged and committed before running rake release.

