### PR TITLE
fix version detection against 4.0.0.M*

### DIFF
--- a/.known_good_references
+++ b/.known_good_references
@@ -1,5 +1,6 @@
 
 /openhab-jruby/5.0
+/openhab-jruby/5.1
 /openhab-jruby/main
 https://bundler.io/
 https://bundler.io/guides/bundler_in_a_single_file_ruby_script.html

--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -490,7 +490,10 @@ module OpenHAB
         def self.const_missing(sym)
           logger.trace("const missing, performing Semantics Lookup for: #{sym}")
           # @deprecated OH3.4 - the Property tag had an ID of "MeasurementProperty" in OH3.4. This was corrected in OH4.
-          sym = :MeasurementProperty if sym == :Property && Gem::Version.new(Core::VERSION) < Gem::Version.new("4.0.0")
+          # make sure we compare against pre-release versions
+          if sym == :Property && Gem::Version.new(Core::VERSION) < Gem::Version.new("4.0.0.M1")
+            sym = :MeasurementProperty
+          end
 
           org.openhab.core.semantics.SemanticTags.get_by_id(sym.to_s)
             &.then do |tag|

--- a/spec/openhab/core/items/semantics_spec.rb
+++ b/spec/openhab/core/items/semantics_spec.rb
@@ -396,7 +396,7 @@ RSpec.describe OpenHAB::Core::Items::Semantics do
     end
 
     # @deprecated OH3.4 -  guard can be removed in OH4
-    unless Gem::Version.new(OpenHAB::Core::VERSION) < Gem::Version.new("4.0.0")
+    unless Gem::Version.new(OpenHAB::Core::VERSION) < Gem::Version.new("4.0.0.M1")
       it "has a synonyms attribute" do
         expect(Semantics::LivingRoom.synonyms).to include("Living Rooms")
       end

--- a/spec/openhab/core/types/hsb_type_spec.rb
+++ b/spec/openhab/core/types/hsb_type_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OpenHAB::Core::Types::HSBType do
   end
 
   it "can be constructed from a hex string" do
-    expect(HSBType.new("#424D3D")).to eql HSBType.new(100, 20, 30)
+    expect(HSBType.new("#424D3D")).to eql HSBType.from_rgb(66, 77, 61)
   end
 
   it "responds to on? and off?" do

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -1266,7 +1266,8 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
           test_it(test_file, check: %i[modified created], watch_args: [@temp_dir, { for: %i[modified created] }])
         end
 
-        if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0") # @deprecated OH3.4 remove this wrapper
+        # @deprecated OH3.4 remove this wrapper
+        if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0.M1")
           # do not remove this test in OH4
           it "uses the built in configWatcher to monitor inside openHAB config folder" do
             expect(OpenHAB::DSL::Rules::Triggers::WatchHandler.factory).not_to receive(:create_watch_service)


### PR DESCRIPTION
This fixes errors such as

```
org.jruby.exceptions.TypeError: (TypeError) compared with non class/module
        at org.jruby.RubyModule.<=(org/jruby/RubyModule.java:2845) ~[?:?]
        at org.jruby.RubyModule.<(org/jruby/RubyModule.java:2879) ~[?:?]
        at RUBY.points(/etc/openhab/automation/ruby/.gem/9.4.2.0/gems/openhab-scripting-5.1.0/lib/openhab/core/items/semantics.rb:625) ~[?:?]```