### PR TITLE
Audio.play_sound called the wrong Java method

### DIFF
--- a/lib/openhab/core/actions/audio.rb
+++ b/lib/openhab/core/actions/audio.rb
@@ -23,14 +23,8 @@ module OpenHAB
           #
           def play_sound(filename, sink: nil, volume: nil)
             volume = PercentType.new(volume) unless volume.is_a?(PercentType) || volume.nil?
-            # JRuby calls the wrong overloaded method when volume is given, but sink is nil
-            # will call playSound(String, String, float) instead of playSound(String, String, PercentType)
-            # and end up with argument type mismatched. So we need to give it a bit of help here.
-            if sink
-              playSound(sink.to_s, filename.to_s, volume)
-            else
-              playSound(filename.to_s, volume)
-            end
+            java_send :playSound, [java.lang.String, java.lang.String, PercentType.java_class],
+                      sink, filename.to_s, volume
           end
 
           #


### PR DESCRIPTION
The previous fix in #43 didn't work.