### PR TITLE
Add unit argument to items builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.4.3", "4.0.0.M2", "4.0.0-SNAPSHOT"]
+        ["3.4.3", "4.0.0.M3", "4.0.0-SNAPSHOT"]
       snapshot_date: |
         ${{ steps.snapshot-date.outputs.SNAPSHOT_DATE }}
     steps:
@@ -128,7 +128,7 @@ jobs:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
         jruby_version: ["jruby-9.3.10.0", "jruby-9.4.2.0"]
         exclude:
-          - openhab_version: 4.0.0.M2
+          - openhab_version: 4.0.0.M3
             jruby_version: jruby-9.3.10.0
           - openhab_version: 4.0.0-SNAPSHOT
             jruby_version: jruby-9.3.10.0

--- a/USAGE.md
+++ b/USAGE.md
@@ -665,6 +665,12 @@ items.build do
   group_item Equipment, tags: Semantics::HVAC, thing: "binding:thing"
     string_item Mode, tags: Semantics::Control, channel: "mode"
   end
+
+  # dimension Temperature inferred
+  number_item OutdoorTemp, format: "%.1f %unit%", unit: "°F"
+    
+  # unit lx, dimension Illuminance, format "%s %unit%" inferred
+  number_item OutdoorBrightness, state: 10_000 | "lx"
 end
 ```
 

--- a/spec/openhab/core/items/number_item_spec.rb
+++ b/spec/openhab/core/items/number_item_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe OpenHAB::Core::Items::NumberItem do
 
   it "respects unit block for commands" do
     items.build do
-      number_item "Feet", dimension: "Length", format: "%d ft"
+      number_item "Feet", unit: "ft"
     end
 
     unit("yd") do

--- a/spec/openhab/core/items/persistence_spec.rb
+++ b/spec/openhab/core/items/persistence_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe OpenHAB::Core::Items::Persistence do
   end
 
   it "handles persistence data with units of measurement" do
-    items.build { number_item "Number_Power", dimension: "Power", format: "%.1f kW", state: 3 }
+    items.build { number_item "Number_Power", state: 3 | "kW" }
     Number_Power.persist
     expect(Number_Power.maximum_since(10.seconds.ago)).to eql(3 | "kW")
   end

--- a/spec/openhab/core/types/quantity_type_spec.rb
+++ b/spec/openhab/core/types/quantity_type_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
 
   it "responds to positive?, negative?, and zero?" do
     items.build do
-      number_item "NumberF", dimension: "Temperature", format: "%d °F", state: "2 °F"
-      number_item "NumberC", dimension: "Temperature", format: "%d °C", state: "2 °C"
-      number_item "PowerPos", dimension: "Power", state: 100 | "W"
-      number_item "PowerNeg", dimension: "Power", state: -100 | "W"
-      number_item "PowerZero", dimension: "Power", state: 0 | "W"
+      number_item "NumberF", state: "2 °F"
+      number_item "NumberC", state: "2 °C"
+      number_item "PowerPos", state: 100 | "W"
+      number_item "PowerNeg", state: -100 | "W"
+      number_item "PowerZero", state: 0 | "W"
       number_item "Number1", state: 20
     end
 

--- a/spec/openhab/dsl/items/ensure_spec.rb
+++ b/spec/openhab/dsl/items/ensure_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe OpenHAB::DSL::Items::Ensure do
     end
 
     it "can send a plain number to a NumberItem with a quantity" do
-      items.build { number_item "Temp", dimension: "Temperature", format: "%d °F", group: AllItems }
+      items.build { number_item "Temp", unit: "°F", group: AllItems }
       Temp.update(80)
       expect(Temp.state).to eq 80 | "°F"
       triggers.clear


### PR DESCRIPTION
sets the metadata, since this is now a very important metadata
in openHAB 4.0

also use it to introduce automatic inference of dimension and format,
making it cross-compatible between OH 3.4 and OH 4.0 (as long as
you're not using a custom format that makes OH 3.4 unable to detect
the unit).

updates CI to OH 4.0.0.M3, and OH 4.0 builds should now be passing