### PR TITLE
Workaround unusual inheritance chain of `main`

### DIFF
--- a/lib/openhab/core_ext/ruby/object.rb
+++ b/lib/openhab/core_ext/ruby/object.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module CoreExt
+    module Ruby
+      # @!visibility private
+      module Object
+        class << self
+          attr_reader :top_self
+        end
+
+        # @!visibility private
+        module ClassMethods
+          # capture methods defined at top level (which get added to Object)
+          def method_added(method)
+            return super unless equal?(::Object)
+
+            if DSL.private_instance_methods.include?(method)
+              # Duplicate methods that conflict with DSL onto `main`'s singleton class,
+              # so that they'll take precedence over DSL's method.
+              Object.top_self.singleton_class.define_method(method, instance_method(method))
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -975,5 +975,8 @@ OpenHAB::Core::Items.import_into_global_namespace
 
 # Extend `main` with DSL methods
 singleton_class.include(OpenHAB::DSL)
+# Patch Object to work around https://github.com/openhab/openhab-jruby/issues/4
+Object.extend(OpenHAB::CoreExt::Ruby::Object::ClassMethods)
+OpenHAB::CoreExt::Ruby::Object.instance_variable_set(:@top_self, self)
 
 logger.debug "openHAB JRuby Scripting Library Version #{OpenHAB::DSL::VERSION} Loaded"


### PR DESCRIPTION
so that DSL methods don't hide user methods

fixes #4