### PR TITLE
Fix intermittent rspec execution on OH4

### DIFF
--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -229,8 +229,17 @@ module OpenHAB
         bundle = org.osgi.framework.FrameworkUtil.get_bundle(org.openhab.core.persistence.PersistenceService.java_class)
         bundle.bundle_context.register_service(org.openhab.core.persistence.PersistenceService.java_class, ps, nil)
 
-        # wait for the rule engine
         rs = OSGi.service("org.openhab.core.service.ReadyService")
+
+        # Add a fake automation:scriptEngineFactories to satisfy startlevel 30
+        begin
+          sef_marker = org.openhab.core.automation.module.script.internal.ScriptEngineFactoryBundleTracker::READY_MARKER
+          rs.mark_ready(sef_marker)
+        rescue NameError
+          # @deprecated OH3.4 NOOP - the ScriptEngineFactoryBundleTracker doesn't exist in OH3
+        end
+
+        # wait for the rule engine
         filter = org.openhab.core.service.ReadyMarkerFilter.new
                     .with_type(org.openhab.core.service.StartLevelService::STARTLEVEL_MARKER_TYPE)
                     .with_identifier(org.openhab.core.service.StartLevelService::STARTLEVEL_RULEENGINE.to_s)


### PR DESCRIPTION
On OH4, Start Level 30 requires the readymarker from ScriptEngineFactoryBundleTracker to be set, but it isn't consistently set when karaf is started by rspec for some reason.

It appears that the bundle `org.openhab.automation.jrubyscripting` never entered the `ACTIVE` state.

So we set a dummy ready marker for it in order to satisfy the start level requirement.