### PR TITLE
Make Configuration objects more Ruby-like

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -677,7 +677,7 @@ end
 
 ### Things
 
-The {OpenHAB::DSL.things things} object allows interactions with openHAB things.
+The {OpenHAB::DSL.things things} object allows interactions with openHAB {OpenHAB::Core::Things::Thing thing}s.
 
 Get Thing Status:
 
@@ -707,6 +707,23 @@ logger.info "TV enabled: #{thing.enabled?}"
 
 thing.enable
 logger.info "TV enabled: #{thing.enabled?}"
+```
+
+Get Thing's configurations:
+
+```ruby
+server = things["smtp:mail:local"].configuration["hostname"]
+logger.info "Configured SMTP Server: #{server}"
+
+frontporch_cam_ip = things["ipcamera:dahua:frontporch"].configuration["ipAddress"]
+logger.info "Front Porch Camera's IP Address: #{frontporch_cam_ip}"
+```
+
+Get Thing's property:
+
+```ruby
+model_id = things["fronius:meter:mybridge:mymeter"].properties["modelId"]
+logger.info "Fronius Smart Meter model: #{model_id}"
 ```
 
 ### Actions

--- a/lib/openhab/core/configuration.rb
+++ b/lib/openhab/core/configuration.rb
@@ -1,53 +1,24 @@
 # frozen_string_literal: true
 
 require "forwardable"
+require_relative "emulate_hash"
 
 module OpenHAB
   module Core
     java_import org.openhab.core.config.core.Configuration
 
+    #
     # {Configuration} represents openHAB's {org.openhab.core.config.core.Configuration} data
-    # with the full interface of {::Hash} and stringifies symbolic keys.
+    # with the full interface of {::Hash}.
+    #
+    # All keys are converted to strings.
+    #
     class Configuration
-      include Enumerable
+      include EmulateHash
       extend Forwardable
 
-      # Make it act like a Hash
-      def_delegators :get_properties,
-                     :any?,
-                     :compact,
-                     :compare_by_identity?,
-                     :deconstruct_keys,
-                     :default,
-                     :default_proc,
-                     :each,
-                     :each_key,
-                     :each_pair,
-                     :each_value,
-                     :empty?,
-                     :filter,
-                     :flatten,
-                     :has_value?,
-                     :invert,
-                     :key,
-                     :length,
-                     :rassoc,
-                     :reject,
-                     :select,
-                     :shift,
-                     :size,
-                     :to_a,
-                     :to_h,
-                     :to_hash,
-                     :transform_keys,
-                     :transform_values,
-                     :values,
-                     :value?
-
-      def_delegator :to_h, :inspect
-
-      # @!visibility private
-      alias_method :to_s, :inspect
+      alias_method :to_map, :properties
+      private :to_map
 
       # @!visibility private
       def [](key)
@@ -55,22 +26,22 @@ module OpenHAB
       end
 
       # @!visibility private
-      def []=(key, value)
+      def store(key, value)
         put(key.to_s, value)
       end
-      alias_method :store, :[]=
 
       # @!visibility private
       def delete(key)
-        remove(key.to_s)
+        key = key.to_s
+        return yield(key) if block_given? && !key?(key)
+
+        remove(key)
       end
 
       # @!visibility private
       def key?(key)
         contains_key(key.to_s)
       end
-      alias_method :has_key?, :key?
-      alias_method :include?, :key?
 
       # @!visibility private
       def replace(new_pairs)
@@ -82,157 +53,17 @@ module OpenHAB
       alias_method :keys, :key_set
 
       # @!visibility private
-      alias_method :hash, :hash_code
-
-      # @!visibility private
       def dup
-        new(self)
-      end
-
-      # @!visibility private
-      def <(other)
-        to_hash < other.to_hash.transform_keys(&:to_s)
-      end
-
-      # @!visibility private
-      def <=(other)
-        to_hash <= other.to_hash.transform_keys(&:to_s)
+        self.class.new(self)
       end
 
       # @!visibility private
       def ==(other)
-        return to_hash == other.transform_keys(&:to_s) if other.is_a?(Hash)
+        if !other.is_a?(self.class) && other.respond_to?(:to_hash)
+          return to_hash == other.to_hash.transform_keys(&:to_s)
+        end
 
         equals(other)
-      end
-
-      # @!visibility private
-      def >(other)
-        to_hash > other.to_hash.transform_keys(&:to_s)
-      end
-
-      # @!visibility private
-      def >=(other)
-        to_hash >= other.to_hash.transform_keys(&:to_s)
-      end
-
-      # @!visibility private
-      def assoc(key)
-        to_h.assoc(key.to_s)
-      end
-
-      # @!visibility private
-      def clear
-        replace({})
-      end
-
-      # @!visibility private
-      def compact!
-        replace(compact)
-      end
-
-      # @!visibility private
-      def compare_by_identity
-        raise NotImplementedError
-      end
-
-      # @!visibility private
-      def default=(*)
-        raise NotImplementedError
-      end
-
-      # @!visibility private
-      def default_proc=(*)
-        raise NotImplementedError
-      end
-
-      # @!visibility private
-      def delete_if(&block)
-        raise NotImplementedError unless block
-
-        replace(to_h.delete_if(&block))
-      end
-
-      # @!visibility private
-      def except(*keys)
-        to_h.except(*keys.map(&:to_s))
-      end
-
-      # @!visibility private
-      def dig(*keys)
-        to_h.dig(*keys.map(&:to_s))
-      end
-
-      # @!visibility private
-      def fetch(key, default = nil)
-        get(key.to_s) || default || (block_given? && yield)
-      end
-
-      # @!visibility private
-      def fetch_values(*keys, &block)
-        to_h.fetch_values(*keys.map(&:to_s), &block)
-      end
-
-      # @!visibility private
-      def keep_if(&block)
-        select!(&block)
-        self
-      end
-
-      # @!visibility private
-      def merge!(*others, &block)
-        return self if others.empty?
-
-        new_config = to_h
-        others.each do |h|
-          new_config.merge!(h.transform_keys(&:to_s), &block)
-        end
-        replace(new_config)
-      end
-      alias_method :update, :merge!
-
-      # @!visibility private
-      def reject!(&block)
-        raise NotImplementedError unless block
-
-        r = to_h.reject!(&block)
-        replace(r) if r
-      end
-
-      # @!visibility private
-      def select!(&block)
-        raise NotImplementedError unless block?
-
-        r = to_h.select!(&block)
-        replace(r) if r
-      end
-      alias_method :filter!, :select!
-
-      # @!visibility private
-      def slice(*keys)
-        to_h.slice(*keys.map(&:to_s))
-      end
-
-      # @!visibility private
-      def to_proc
-        ->(k) { self[k] }
-      end
-
-      # @!visibility private
-      def transform_keys!(*args, &block)
-        replace(transform_keys(*args, &block))
-      end
-
-      # @!visibility private
-      def transform_values!(&block)
-        raise NotImplementedError unless block
-
-        replace(transform_values(&block))
-      end
-
-      # @!visibility private
-      def values_at(*keys)
-        to_h.values_at(*keys.map(&:to_s))
       end
     end
   end

--- a/lib/openhab/core/configuration.rb
+++ b/lib/openhab/core/configuration.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module OpenHAB
+  module Core
+    java_import org.openhab.core.config.core.Configuration
+
+    # {Configuration} represents openHAB's {org.openhab.core.config.core.Configuration} data
+    # with the full interface of {::Hash} and stringifies symbolic keys.
+    class Configuration
+      include Enumerable
+      extend Forwardable
+
+      # Make it act like a Hash
+      def_delegators :get_properties,
+                     :any?,
+                     :compact,
+                     :compare_by_identity?,
+                     :deconstruct_keys,
+                     :default,
+                     :default_proc,
+                     :each,
+                     :each_key,
+                     :each_pair,
+                     :each_value,
+                     :empty?,
+                     :filter,
+                     :flatten,
+                     :has_value?,
+                     :invert,
+                     :key,
+                     :length,
+                     :rassoc,
+                     :reject,
+                     :select,
+                     :shift,
+                     :size,
+                     :to_a,
+                     :to_h,
+                     :to_hash,
+                     :transform_keys,
+                     :transform_values,
+                     :values,
+                     :value?
+
+      def_delegator :to_h, :inspect
+
+      # @!visibility private
+      alias_method :to_s, :inspect
+
+      # @!visibility private
+      def [](key)
+        get(key.to_s)
+      end
+
+      # @!visibility private
+      def []=(key, value)
+        put(key.to_s, value)
+      end
+      alias_method :store, :[]=
+
+      # @!visibility private
+      def delete(key)
+        remove(key.to_s)
+      end
+
+      # @!visibility private
+      def key?(key)
+        contains_key(key.to_s)
+      end
+      alias_method :has_key?, :key?
+      alias_method :include?, :key?
+
+      # @!visibility private
+      def replace(new_pairs)
+        set_properties(new_pairs.to_h.transform_keys(&:to_s))
+        self
+      end
+
+      # @!visibility private
+      alias_method :keys, :key_set
+
+      # @!visibility private
+      alias_method :hash, :hash_code
+
+      # @!visibility private
+      def dup
+        new(self)
+      end
+
+      # @!visibility private
+      def <(other)
+        to_hash < other.to_hash.transform_keys(&:to_s)
+      end
+
+      # @!visibility private
+      def <=(other)
+        to_hash <= other.to_hash.transform_keys(&:to_s)
+      end
+
+      # @!visibility private
+      def ==(other)
+        return to_hash == other.transform_keys(&:to_s) if other.is_a?(Hash)
+
+        equals(other)
+      end
+
+      # @!visibility private
+      def >(other)
+        to_hash > other.to_hash.transform_keys(&:to_s)
+      end
+
+      # @!visibility private
+      def >=(other)
+        to_hash >= other.to_hash.transform_keys(&:to_s)
+      end
+
+      # @!visibility private
+      def assoc(key)
+        to_h.assoc(key.to_s)
+      end
+
+      # @!visibility private
+      def clear
+        replace({})
+      end
+
+      # @!visibility private
+      def compact!
+        replace(compact)
+      end
+
+      # @!visibility private
+      def compare_by_identity
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def default=(*)
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def default_proc=(*)
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def delete_if(&block)
+        raise NotImplementedError unless block
+
+        replace(to_h.delete_if(&block))
+      end
+
+      # @!visibility private
+      def except(*keys)
+        to_h.except(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def dig(*keys)
+        to_h.dig(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def fetch(key, default = nil)
+        get(key.to_s) || default || (block_given? && yield)
+      end
+
+      # @!visibility private
+      def fetch_values(*keys, &block)
+        to_h.fetch_values(*keys.map(&:to_s), &block)
+      end
+
+      # @!visibility private
+      def keep_if(&block)
+        select!(&block)
+        self
+      end
+
+      # @!visibility private
+      def merge!(*others, &block)
+        return self if others.empty?
+
+        new_config = to_h
+        others.each do |h|
+          new_config.merge!(h.transform_keys(&:to_s), &block)
+        end
+        replace(new_config)
+      end
+      alias_method :update, :merge!
+
+      # @!visibility private
+      def reject!(&block)
+        raise NotImplementedError unless block
+
+        r = to_h.reject!(&block)
+        replace(r) if r
+      end
+
+      # @!visibility private
+      def select!(&block)
+        raise NotImplementedError unless block?
+
+        r = to_h.select!(&block)
+        replace(r) if r
+      end
+      alias_method :filter!, :select!
+
+      # @!visibility private
+      def slice(*keys)
+        to_h.slice(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def to_proc
+        ->(k) { self[k] }
+      end
+
+      # @!visibility private
+      def transform_keys!(*args, &block)
+        replace(transform_keys(*args, &block))
+      end
+
+      # @!visibility private
+      def transform_values!(&block)
+        raise NotImplementedError unless block
+
+        replace(transform_values(&block))
+      end
+
+      # @!visibility private
+      def values_at(*keys)
+        to_h.values_at(*keys.map(&:to_s))
+      end
+    end
+  end
+end

--- a/lib/openhab/core/emulate_hash.rb
+++ b/lib/openhab/core/emulate_hash.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module OpenHAB
+  module Core
+    #
+    # Make a class acts like a Ruby Hash that supports indifferent keys.
+    #
+    # Methods that accepts keys will convert symbolic keys to string keys, but only shallowly.
+    # This key indifference does not extend to Hash return values, however.
+    # Hash return values will behave like a normal Hash
+    # which treats symbolic and string keys differently.
+    #
+    # The including class must implement at least:
+    # - `#to_map` to provide the hash-like data
+    # - `#replace`
+    # - `#store`
+    # - Other methods and mutators as applicable to the underlying storage.
+    #
+    module EmulateHash
+      include Enumerable
+      extend Forwardable
+
+      # Methods delegated to to_map
+      DELEGATED_METHODS = %i[>
+                             >=
+                             <
+                             <=
+                             ==
+                             any?
+                             compact
+                             deconstruct_keys
+                             transform_keys
+                             to_hash
+                             length
+                             size
+                             compare_by_identity?
+                             each
+                             each_key
+                             each_pair
+                             each_value
+                             equals
+                             empty?
+                             filter
+                             flatten
+                             has_value?
+                             invert
+                             key
+                             keys
+                             rassoc
+                             reject
+                             select
+                             shift
+                             to_a
+                             to_h
+                             to_hash
+                             transform_keys
+                             transform_values
+                             value?
+                             values].freeze
+      private_constant :DELEGATED_METHODS
+
+      def_delegators :to_map, *DELEGATED_METHODS
+
+      def_delegator :to_h, :inspect
+
+      # @!visibility private
+      alias_method :to_s, :inspect
+
+      # @!visibility private
+      def except(*keys)
+        to_map.except(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def key?(key)
+        to_map.key?(key.to_s)
+      end
+      alias_method :has_key?, :key?
+      alias_method :include?, :key?
+
+      #
+      # @see https://ruby-doc.org/core/Hash.html#method-i-merge
+      #
+      # java.util.Map#merge is incompatible to Ruby's, but JRuby provides #ruby_merge for it
+      #
+      # @!visibility private
+      def merge(*others, &block)
+        return self if others.empty?
+
+        others.map! { |hash| hash.transform_keys(&:to_s) }
+        map = to_map
+        if map.respond_to?(:ruby_merge)
+          map.ruby_merge(*others, &block)
+        else
+          # fall back to #merge in case #to_map returns a Ruby Hash
+          map.merge(*others, &block)
+        end
+      end
+
+      # @!visibility private
+      def merge!(*others, &block)
+        return self if others.empty?
+
+        replace(merge(*others, &block))
+      end
+      alias_method :update, :merge!
+
+      # @!visibility private
+      def replace
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def slice(*keys)
+        to_map.slice(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def fetch(key, *default, &block)
+        to_map.fetch(key.to_s, *default, &block)
+      end
+
+      # @!visibility private
+      def [](key)
+        fetch(key, nil)
+      end
+
+      # @!visibility private
+      def store(key, value)
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def []=(key, value)
+        store(key, value)
+      end
+
+      # @!visibility private
+      def assoc(key)
+        to_map.assoc(key.to_s)
+      end
+
+      # @!visibility private
+      def clear
+        replace({})
+      end
+
+      # @!visibility private
+      def dig(key, *keys)
+        to_map.dig(key.to_s, *keys)
+      end
+
+      # @!visibility private
+      def compact!
+        to_h.compact!&.then { |r| replace(r) }
+      end
+
+      # @!visibility private
+      def delete_if(&block)
+        raise NotImplementedError unless block
+
+        replace(to_h.delete_if(&block))
+      end
+
+      # @!visibility private
+      def keep_if(&block)
+        select!(&block)
+        self
+      end
+
+      # @!visibility private
+      def select!(&block)
+        raise NotImplementedError unless block
+
+        to_h.select!(&block)&.then { |r| replace(r) }
+      end
+      alias_method :filter!, :select!
+
+      # @!visibility private
+      def reject!(&block)
+        raise NotImplementedError unless block
+
+        to_h.reject!(&block)&.then { |r| replace(r) }
+      end
+
+      # @!visibility private
+      def fetch_values(*keys, &block)
+        to_map.fetch_values(*keys.map(&:to_s), &block)
+      end
+
+      # @!visibility private
+      def transform_keys!(*args, &block)
+        replace(transform_keys(*args, &block))
+      end
+
+      # @!visibility private
+      def transform_values!(&block)
+        raise NotImplementedError unless block
+
+        replace(transform_values(&block))
+      end
+
+      # @!visibility private
+      def values_at(*keys)
+        to_map.values_at(*keys.map(&:to_s))
+      end
+
+      # @!visibility private
+      def compare_by_identity
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def default=(*)
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def default_proc=(*)
+        raise NotImplementedError
+      end
+
+      # @!visibility private
+      def default(*)
+        nil
+      end
+
+      # @!visibility private
+      def default_proc
+        nil
+      end
+
+      # @!visibility private
+      def to_proc
+        ->(k) { self[k] }
+      end
+    end
+  end
+end

--- a/lib/openhab/core/things/links/provider.rb
+++ b/lib/openhab/core/things/links/provider.rb
@@ -25,7 +25,7 @@ module OpenHAB
 
             # @!visibility private
             def link(item, channel, config = {})
-              config = org.openhab.core.config.core.Configuration.new(config.transform_keys(&:to_s))
+              config = Configuration.new(config.transform_keys(&:to_s))
               channel = ChannelUID.new(channel) if channel.is_a?(String)
               channel = channel.uid if channel.is_a?(Channel)
               link = org.openhab.core.thing.link.ItemChannelLink.new(item.name, channel, config)

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -43,7 +43,7 @@ module OpenHAB
       #
       # @!attribute [r] bridge_uid
       #   Return the Bridge UID when available.
-      #   @return [org.openhab.core.thing.ThingUID, nil]
+      #   @return [org.openhab.core.thing.ThingUID]
       #
       # @!attribute [r] configuration
       #   Return the thing's configuration.

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -37,6 +37,29 @@ module OpenHAB
       # @!attribute [r] channels
       #   @return [ChannelArray]
       #
+      # @!attribute [r] uid
+      #   Return the UID.
+      #   @return [org.openhab.core.thing.ThingUID]
+      #
+      # @!attribute [r] bridge_uid
+      #   Return the Bridge UID when available.
+      #   @return [org.openhab.core.thing.ThingUID, nil]
+      #
+      # @!attribute [r] configuration
+      #   Return the thing's configuration.
+      #   @return [OpenHAB::Core::Configuration]
+      #
+      #   @example
+      #     logger.info things["smtp:mail:local"].configuration["hostname"]
+      #     logger.info things["ipcamera:dahua:frontporch"].configuration["ipAddress"]
+      #
+      # @!attribute [r] properties
+      #   Return the properties when available.
+      #   @return [Hash]
+      #
+      #   @example
+      #     logger.info things["fronius:meter:mybridge:mymeter"].properties["modelId"]
+      #
       module Thing
         # Array wrapper class to allow searching a list of channels
         # by channel id

--- a/lib/openhab/dsl/rules/rule_triggers.rb
+++ b/lib/openhab/dsl/rules/rule_triggers.rb
@@ -64,7 +64,7 @@ module OpenHAB
           org.openhab.core.automation.util.TriggerBuilder.create
              .with_id(uuid)
              .with_type_uid(type)
-             .with_configuration(org.openhab.core.config.core.Configuration.new(config))
+             .with_configuration(Core::Configuration.new(config))
              .build
         end
 

--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -184,7 +184,7 @@ module OpenHAB
 
         # @!visibility private
         def build
-          configuration = org.openhab.core.config.core.Configuration.new(config)
+          configuration = Core::Configuration.new(config)
           if thing_type
             self.class.thing_factory_helper.apply_default_configuration(
               configuration, thing_type,
@@ -280,7 +280,7 @@ module OpenHAB
           org.openhab.core.thing.binding.builder.ChannelBuilder.create(uid)
              .with_kind(kind)
              .with_type(type)
-             .with_configuration(org.openhab.core.config.core.Configuration.new(config))
+             .with_configuration(Core::Configuration.new(config))
              .build
         end
 

--- a/spec/openhab/core/configuration_spec.rb
+++ b/spec/openhab/core/configuration_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenHAB::Core::Configuration do
+  let(:contents) do
+    { "key1" => "value1", "key2" => "value2" }.freeze
+  end
+
+  let(:configuration) do
+    described_class.new(contents)
+  end
+
+  describe "#inspect" do
+    it "logs the full configuration" do
+      expect(configuration.inspect).to eql contents.inspect
+    end
+  end
+
+  describe "#to_h" do
+    it "works" do
+      expect(configuration.to_h).to eql contents
+    end
+  end
+
+  describe "#[]" do
+    it "works" do
+      expect(configuration["key1"]).to eql "value1"
+    end
+
+    it "returns nil for nonexistent key" do
+      expect(configuration["nonexistent"]).to be_nil
+    end
+
+    it "stringifies config keys" do
+      expect(configuration[:key1]).to eql "value1"
+    end
+  end
+
+  describe "#[]=" do
+    it "works" do
+      configuration["key1"] = "newvalue"
+      expect(configuration["key1"]).to eql "newvalue"
+    end
+
+    it "stringifies config keys" do
+      configuration[:key1] = "stringified"
+      expect(configuration["key1"]).to eql "stringified"
+    end
+
+    it "can be added via hash" do
+      configuration["newkey"] = "corge"
+      expect(configuration["newkey"]).to eql "corge"
+    end
+  end
+
+  describe "#dig" do
+    it "works" do
+      expect(configuration.dig("key1")).to eql "value1" # rubocop:disable Style/SingleArgumentDig
+    end
+
+    it "stringifies keys" do
+      expect(configuration.dig(:key1)).to eql "value1" # rubocop:disable Style/SingleArgumentDig
+    end
+  end
+
+  describe "#==" do
+    it "can compare against a ::Hash" do
+      expect(configuration).to eq(contents)
+    end
+
+    it "can compare against another Configuration object" do
+      expect(configuration).to eq(described_class.new(contents))
+    end
+  end
+
+  describe "#replace" do
+    it "works" do
+      configuration.replace("x" => "y")
+      expect(configuration.to_h).to eql("x" => "y")
+    end
+
+    it "stringifies keys" do
+      configuration.replace(symkey: "ruby")
+      expect(configuration.to_h).to eql("symkey" => "ruby")
+    end
+
+    it "accepts another Configuration" do
+      configuration.replace(described_class.new("ma" => "goo"))
+      expect(configuration.to_h).to eql("ma" => "goo")
+    end
+  end
+
+  describe "#delete" do
+    it "works" do
+      configuration.delete("key1")
+      expect(configuration.to_h).to eql("key2" => "value2")
+    end
+  end
+
+  describe "#key?" do
+    it "works" do
+      expect(configuration.key?("key1")).to be true
+      expect(configuration.key?("nonexistent")).to be false
+    end
+
+    it "stringifies the given key" do
+      expect(configuration.key?(:key1)).to be true
+    end
+  end
+
+  describe "#include?" do
+    it "works" do
+      expect(configuration.include?("key1")).to be true
+      expect(configuration.include?("nonexistent")).to be false
+    end
+
+    it "stringifies the given key" do
+      expect(configuration.include?(:key1)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Also document additional Thing attributes.

Classes `Core::Items::Metadata::NamespaceHash` and `Core::Items::Metadata::Hash` were refactored and the common code moved into `EmulateHash`.
