### PR TITLE
handle RSpec.current_example being nil

### DIFF
--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -84,7 +84,7 @@ module OpenHAB
               @debouncer.call { process_queue(create_queue(event), mod, event) }
             end
           rescue Exception => e
-            raise if defined?(::RSpec) && ::RSpec.current_example.example_group.propagate_exceptions?
+            raise if defined?(::RSpec) && ::RSpec.current_example&.example_group&.propagate_exceptions?
 
             @run_context.send(:logger).log_exception(e)
           end


### PR DESCRIPTION
this can happen during watch specs, with have a background thread, and thus trigger the event after the spec has completed

fixes #122