### PR TITLE
Make `event.group` also available in UI rules 

### DIFF
--- a/lib/openhab/core/events/item_event.rb
+++ b/lib/openhab/core/events/item_event.rb
@@ -31,7 +31,11 @@ module OpenHAB
         # @since openHAB 4.0
         #
         def group
-          inputs["triggeringGroup"]&.then { |triggering_group| Items::Proxy.new(triggering_group) }
+          triggering_group = inputs&.[]("triggeringGroup") ||
+                             CoreExt::Ruby::Object.top_self
+                                                  .instance_eval { triggeringGroup if defined?(triggeringGroup) }
+
+          Items::Proxy.new(triggering_group) if triggering_group
         end
       end
     end


### PR DESCRIPTION
~Until we've figured a way to get it in the event object.~
~I think a change in openhab core to insert it into event payload may be necessary.~

~Found a way to grab the top level local variable in UI rules.~