### PR TITLE
Revert "Add `event.inputs`; and `event.group` attributes for triggeringGroup (#123)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -263,15 +263,14 @@ See [File Based Rules](#file-based-rules) for examples of creating rules within 
 
 When you use "Item event" as trigger (i.e. "[item] received a command", "[item] was updated", "[item] changed"), there is additional context available for the action in a variable called `event`.
 
-This table gives an overview of the `event` object for the most common trigger types. For full details, explore {OpenHAB::Core::Events}.
+This tables gives an overview of the `event` object for most common trigger types. For full details, explore {OpenHAB::Core::Events}.
 
-| Property Name | Type                                         | Trigger Types                                                                                        | Description                                              | Rules DSL Equivalent   |
-| ------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------- |
-| `state`       | {OpenHAB::Core::Types::State State} or `nil` | `[item] changed`, `[item] was updated`                                                               | State that triggered the event                           | `triggeringItem.state` |
-| `was`         | {OpenHAB::Core::Types::State State} or `nil` | `[item] changed`                                                                                     | Previous state of Item or Group that triggered the event | `previousState`        |
-| `command`     | {OpenHAB::Core::Types::Command Command}      | `[item] received a command`                                                                          | Command that triggered the event                         | `receivedCommand`      |
-| `item`        | {OpenHAB::Core::Items::Item Item}            | all                                                                                                  | Item that triggered the event                            | `triggeringItem`       |
-| `group`       | {OpenHAB::Core::Items::Item GroupItem}       | `Member of [group] changed`, `Member of [group] was updated`, `Member of [group] received a command` | Group whose member triggered the event                   | `triggeringGroup`      |
+| Property Name | Type                                         | Trigger Types                          | Description                                          | Rules DSL Equivalent   |
+| ------------- | -------------------------------------------- | -------------------------------------- | ---------------------------------------------------- | ---------------------- |
+| `state`       | {OpenHAB::Core::Types::State State} or `nil` | `[item] changed`, `[item] was updated` | State that triggered event                           | `triggeringItem.state` |
+| `was`         | {OpenHAB::Core::Types::State State} or `nil` | `[item] changed`                       | Previous state of Item or Group that triggered event | `previousState`        |
+| `command`     | {OpenHAB::Core::Types::Command Command}      | `[item] received a command`            | Command that triggered event                         | `receivedCommand`      |
+| `item`        | {OpenHAB::Core::Items::Item Item}            | all                                    | Item that triggered event                            | `triggeringItem`       |
 
 ```ruby
 logger.info(event.state == ON)

--- a/lib/openhab/core/events/abstract_event.rb
+++ b/lib/openhab/core/events/abstract_event.rb
@@ -10,9 +10,6 @@ module OpenHAB
         # @return [Object]
         attr_accessor :attachment
 
-        # @return [Hash]
-        attr_accessor :inputs
-
         # @return [String]
         alias_method :inspect, :to_s
 

--- a/lib/openhab/core/events/item_event.rb
+++ b/lib/openhab/core/events/item_event.rb
@@ -16,23 +16,6 @@ module OpenHAB
         def item
           EntityLookup.lookup_item(item_name)
         end
-
-        #
-        # @!attribute [r] group
-        #
-        # The group item whose member had triggered this event.
-        #
-        # This is the equivalent of openHAB's `triggeringGroup`, and it is only available
-        # on a member-of-group trigger.
-        #
-        # @return [Item,nil] The group item whose member had triggered this event.
-        #   `nil` when the event wasn't triggered by a member-of-group trigger.
-        #
-        # @since openHAB 4.0
-        #
-        def group
-          inputs["triggeringGroup"]&.then { |triggering_group| Items::Proxy.new(triggering_group) }
-        end
       end
     end
   end

--- a/lib/openhab/dsl/rules/automation_rule.rb
+++ b/lib/openhab/dsl/rules/automation_rule.rb
@@ -143,8 +143,6 @@ module OpenHAB
             end
 
             event.attachment = attachment
-            # WatchEvent and future custom events may not need/support inputs
-            event.inputs = inputs if event.respond_to?(:inputs=)
             return event
           end
 

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -346,22 +346,6 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
                              from: 4,
                              to: proc { true })
 
-        # @deprecated OH3.4 the if guard for OH3
-        if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0")
-          it "reports the triggering group" do
-            triggering_group = nil
-            Switch1.update(ON)
-
-            rule do
-              changed Switches.members
-              run { |event| triggering_group = event.group }
-            end
-
-            Switch1.update(OFF)
-            expect(triggering_group).to eql Switches
-          end
-        end
-
         describe "duration" do
           before do
             items.build { number_item "Alarm_Delay", state: 5 }
@@ -424,23 +408,6 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
             expect(triggered_item).to be_nil
             time_travel_and_execute_timers(20.seconds)
             expect(triggered_item).to be_nil
-          end
-
-          # @deprecated OH3.4 the if guard for OH3
-          if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0")
-            it "reports the triggering group" do
-              triggering_group = nil
-              Switch1.update(ON)
-
-              rule do
-                changed Switches.members, for: 0.5.seconds
-                run { |event| triggering_group = event.group }
-              end
-
-              Switch1.update(OFF)
-              time_travel_and_execute_timers(1.second)
-              expect(triggering_group).to eql Switches
-            end
           end
 
           context "without to state" do
@@ -807,20 +774,6 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
       test_command_trigger("AlarmModes", members: true, command: [7, 14], expect_triggered: false) do
         Alarm_Mode << 10
       end
-
-      # @deprecated OH3.4 the if guard for OH3
-      if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0")
-        it "reports the triggering group" do
-          triggering_group = nil
-          rule do
-            received_command AlarmModes.members
-            run { |event| triggering_group = event.group }
-          end
-
-          Alarm_Mode.command(1)
-          expect(triggering_group).to eql AlarmModes
-        end
-      end
     end
 
     describe "#trigger" do
@@ -996,20 +949,6 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
 
           Alarm_Mode.update(7)
           expect(items).to eql [Alarm_Mode]
-        end
-
-        # @deprecated OH3.4 the if guard for OH3
-        if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0")
-          it "reports the triggering group" do
-            triggering_group = nil
-            rule do
-              updated AlarmModes.members
-              run { |event| triggering_group = event.group }
-            end
-
-            Alarm_Mode.update(1)
-            expect(triggering_group).to eql AlarmModes
-          end
         end
 
         it "works with group members to specific states" do


### PR DESCRIPTION
This reverts commit 8cb45f6fc826d0e251a992a63f05a0a4576caef5.

Reasons:
* Unable to access toplevel UI local variables to get to `triggeringGroup`, so #123 created an inconsistency where event.group is only available on file-based rules
* File-based rules now has access to top level context so it can use `triggeringGroup` just like UI rules, since #133
