### PR TITLE
Add unit conversion operator (|) to java.math.BigDecimal

### DIFF
--- a/lib/openhab/core_ext/ruby/numeric.rb
+++ b/lib/openhab/core_ext/ruby/numeric.rb
@@ -190,6 +190,7 @@ module OpenHAB
       # Integer already has #|, so we have to prepend it here
       ::Integer.prepend(QuantityTypeConversion)
       ::Numeric.include(Numeric)
+      java.math.BigDecimal.include(QuantityTypeConversion)
     end
   end
 end

--- a/spec/openhab/core_ext/ruby/numeric_spec.rb
+++ b/spec/openhab/core_ext/ruby/numeric_spec.rb
@@ -15,5 +15,9 @@ RSpec.describe Numeric do
     it "falls back to the default behavior on non unit" do
       expect(1 | 2).to eq 3
     end
+
+    it "works with Java BigDecimal" do
+      expect(java.math.BigDecimal::ZERO | "W").to eq QuantityType.new("0 W")
+    end
   end
 end


### PR DESCRIPTION
In case you're using it with StateDescription or any other Java object that returns Java's BigDecimal