### PR TITLE
Fix QuantityType arithmetic of mixed units

### DIFF
--- a/spec/openhab/core/types/quantity_type_spec.rb
+++ b/spec/openhab/core/types/quantity_type_spec.rb
@@ -8,26 +8,45 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
   end
 
   describe "math operations" do
-    it "supports quantity type operand" do
-      expect(QuantityType.new("50 °F") + QuantityType.new("50 °F")).to eql QuantityType.new("100.0 °F")
-      expect(QuantityType.new("50 °F") - QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
-      expect((QuantityType.new("100 W") / QuantityType.new("2 W")).to_i).to be 50
-      expect(QuantityType.new("50 °F") + -QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+    describe "additions and subtractions" do
+      it "support quantity type operand" do
+        expect(QuantityType.new("50 °F") + QuantityType.new("50 °F")).to eql QuantityType.new("100.0 °F")
+        expect(QuantityType.new("50 °F") - QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+        expect(QuantityType.new("50 °F") + -QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+      end
+
+      it "raise exception with non QuantityType operand" do
+        expect { QuantityType.new("50 °F") + 50 }.to raise_exception(TypeError)
+        expect { QuantityType.new("50 °F") - 50 }.to raise_exception(TypeError)
+        expect { 50 + QuantityType.new("50 °F") }.to raise_exception(javax.measure.UnconvertibleException)
+        expect { 50 - QuantityType.new("50 °F") }.to raise_exception(javax.measure.UnconvertibleException)
+      end
     end
 
-    it "supports numeric operand" do
-      expect(QuantityType.new("50 W") * 2).to eql QuantityType.new("100.0 W")
-      expect(2 * QuantityType.new("50 W")).to eql QuantityType.new("100.0 W")
-      expect(QuantityType.new("100 W") / 2).to eql QuantityType.new("50.0 W")
-      expect(QuantityType.new("50 W") * 2.0).to eql QuantityType.new("100.0 W")
-      expect(QuantityType.new("100 W") / 2.0).to eql QuantityType.new("50.0 W")
-    end
+    describe "multiplications and divisions" do
+      it "support quantity type operand" do
+        expect(QuantityType.new("100 W") * QuantityType.new("2 W")).to eql QuantityType.new("200 W²")
+        expect(QuantityType.new("100 W") / QuantityType.new("2 W")).to eql QuantityType.new("50")
+      end
 
-    it "supports DecimalType operand" do
-      expect(QuantityType.new("50 W") * DecimalType.new(2)).to eql QuantityType.new("100.0 W")
-      expect(QuantityType.new("100 W") / DecimalType.new(2)).to eql QuantityType.new("50.0 W")
-      expect(QuantityType.new("50 W") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 W")
-      expect(QuantityType.new("100 W") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 W")
+      it "support numeric operand" do
+        expect(QuantityType.new("50 W") * 2).to eql QuantityType.new("100.0 W")
+        expect(QuantityType.new("50 kW") * 2).to eql QuantityType.new("100.0 kW")
+        expect(2 * QuantityType.new("50 W")).to eql QuantityType.new("100.0 W")
+        expect(2 * QuantityType.new("50 kW")).to eql QuantityType.new("100.0 kW")
+        expect(QuantityType.new("100 W") / 2).to eql QuantityType.new("50.0 W")
+        expect(QuantityType.new("50 W") * 2.0).to eql QuantityType.new("100.0 W")
+        expect(2.0 * QuantityType.new("50 W")).to eql QuantityType.new("100.0 W")
+        expect(2.0 * QuantityType.new("50 kW")).to eql QuantityType.new("100.0 kW")
+        expect(QuantityType.new("100 W") / 2.0).to eql QuantityType.new("50.0 W")
+      end
+
+      it "support DecimalType operand" do
+        expect(QuantityType.new("50 W") * DecimalType.new(2)).to eql QuantityType.new("100.0 W")
+        expect(QuantityType.new("100 W") / DecimalType.new(2)).to eql QuantityType.new("50.0 W")
+        expect(QuantityType.new("50 W") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 W")
+        expect(QuantityType.new("100 W") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 W")
+      end
     end
 
     describe "with mixed units" do

--- a/spec/openhab/core/types/quantity_type_spec.rb
+++ b/spec/openhab/core/types/quantity_type_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
     # quantity type operand
     expect(QuantityType.new("50 °F") + QuantityType.new("50 °F")).to eql QuantityType.new("100.0 °F")
     expect(QuantityType.new("50 °F") - QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
-    expect((QuantityType.new("100 °F") / QuantityType.new("2 °F")).to_i).to be 50
+    expect((QuantityType.new("100 W") / QuantityType.new("2 W")).to_i).to be 50
     expect(QuantityType.new("50 °F") + -QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
 
     # numeric operand
-    expect(QuantityType.new("50 °F") * 2).to eql QuantityType.new("100.0 °F")
-    expect(QuantityType.new("100 °F") / 2).to eql QuantityType.new("50.0 °F")
-    expect(QuantityType.new("50 °F") * 2.0).to eql QuantityType.new("100.0 °F")
-    expect(QuantityType.new("100 °F") / 2.0).to eql QuantityType.new("50.0 °F")
+    expect(QuantityType.new("50 W") * 2).to eql QuantityType.new("100.0 W")
+    expect(QuantityType.new("100 W") / 2).to eql QuantityType.new("50.0 W")
+    expect(QuantityType.new("50 W") * 2.0).to eql QuantityType.new("100.0 W")
+    expect(QuantityType.new("100 W") / 2.0).to eql QuantityType.new("50.0 W")
 
     # DecimalType operand
-    expect(QuantityType.new("50 °F") * DecimalType.new(2)).to eql QuantityType.new("100.0 °F")
-    expect(QuantityType.new("100 °F") / DecimalType.new(2)).to eql QuantityType.new("50.0 °F")
-    expect(QuantityType.new("50 °F") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 °F")
-    expect(QuantityType.new("100 °F") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 °F")
+    expect(QuantityType.new("50 W") * DecimalType.new(2)).to eql QuantityType.new("100.0 W")
+    expect(QuantityType.new("100 W") / DecimalType.new(2)).to eql QuantityType.new("50.0 W")
+    expect(QuantityType.new("50 W") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 W")
+    expect(QuantityType.new("100 W") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 W")
   end
 
   it "can be compared" do

--- a/spec/openhab/core/types/quantity_type_spec.rb
+++ b/spec/openhab/core/types/quantity_type_spec.rb
@@ -7,24 +7,46 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
     expect(50.to_d | "°F").to eql QuantityType.new("50.0 °F") # rubocop:disable Performance/BigDecimalWithNumericArgument
   end
 
-  it "responds to math operations" do
-    # quantity type operand
-    expect(QuantityType.new("50 °F") + QuantityType.new("50 °F")).to eql QuantityType.new("100.0 °F")
-    expect(QuantityType.new("50 °F") - QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
-    expect((QuantityType.new("100 W") / QuantityType.new("2 W")).to_i).to be 50
-    expect(QuantityType.new("50 °F") + -QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+  describe "math operations" do
+    it "supports quantity type operand" do
+      expect(QuantityType.new("50 °F") + QuantityType.new("50 °F")).to eql QuantityType.new("100.0 °F")
+      expect(QuantityType.new("50 °F") - QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+      expect((QuantityType.new("100 W") / QuantityType.new("2 W")).to_i).to be 50
+      expect(QuantityType.new("50 °F") + -QuantityType.new("25 °F")).to eql QuantityType.new("25.0 °F")
+    end
 
-    # numeric operand
-    expect(QuantityType.new("50 W") * 2).to eql QuantityType.new("100.0 W")
-    expect(QuantityType.new("100 W") / 2).to eql QuantityType.new("50.0 W")
-    expect(QuantityType.new("50 W") * 2.0).to eql QuantityType.new("100.0 W")
-    expect(QuantityType.new("100 W") / 2.0).to eql QuantityType.new("50.0 W")
+    it "supports numeric operand" do
+      expect(QuantityType.new("50 W") * 2).to eql QuantityType.new("100.0 W")
+      expect(2 * QuantityType.new("50 W")).to eql QuantityType.new("100.0 W")
+      expect(QuantityType.new("100 W") / 2).to eql QuantityType.new("50.0 W")
+      expect(QuantityType.new("50 W") * 2.0).to eql QuantityType.new("100.0 W")
+      expect(QuantityType.new("100 W") / 2.0).to eql QuantityType.new("50.0 W")
+    end
 
-    # DecimalType operand
-    expect(QuantityType.new("50 W") * DecimalType.new(2)).to eql QuantityType.new("100.0 W")
-    expect(QuantityType.new("100 W") / DecimalType.new(2)).to eql QuantityType.new("50.0 W")
-    expect(QuantityType.new("50 W") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 W")
-    expect(QuantityType.new("100 W") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 W")
+    it "supports DecimalType operand" do
+      expect(QuantityType.new("50 W") * DecimalType.new(2)).to eql QuantityType.new("100.0 W")
+      expect(QuantityType.new("100 W") / DecimalType.new(2)).to eql QuantityType.new("50.0 W")
+      expect(QuantityType.new("50 W") * DecimalType.new(2.0)).to eql QuantityType.new("100.0 W")
+      expect(QuantityType.new("100 W") / DecimalType.new(2.0)).to eql QuantityType.new("50.0 W")
+    end
+
+    describe "with mixed units" do
+      it "normalizes units in complex expression" do
+        expect(((23 | "°C") | "°F") - (70 | "°F")).to be < 4 | "°F"
+      end
+
+      it "supports arithmetic" do
+        expect((20 | "°C") + (9 | "°F")).to eql 25 | "°C"
+        expect((25 | "°C") - (9 | "°F")).to eql 20 | "°C"
+      end
+
+      it "works in a unit block" do
+        unit("°C") do
+          expect((20 | "°C") + (9 | "°F")).to eql 25 | "°C"
+          expect((25 | "°C") - (9 | "°F")).to eql 20 | "°C"
+        end
+      end
+    end
   end
 
   it "can be compared" do
@@ -69,10 +91,6 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
     expect((0 | "W")..(10 | "W")).to cover(0 | "W")
     expect((0 | "W")..(10 | "W")).not_to cover(14 | "W")
     expect((0 | "W")..(10 | "W")).to cover(10 | "W")
-  end
-
-  it "normalizes units in complex expression" do
-    expect(((23 | "°C") | "°F") - (70 | "°F")).to be < 4 | "°F"
   end
 
   describe "comparisons" do

--- a/spec/openhab/dsl_spec.rb
+++ b/spec/openhab/dsl_spec.rb
@@ -244,6 +244,8 @@ RSpec.describe OpenHAB::DSL do
     it "converts all units and numbers to specific unit for all operations" do
       c = 23 | "°C"
       f = 70 | "°F"
+      # f.to_unit(SIUnits::CELSIUS) = 21.11 °C
+      # f.to_unit_relative(SIUnits::CELSIUS) = 38.89 °C
       unit("°F") do
         expect(c - f < 4).to be true
         expect(c - (24 | "°C") < 32).to be true
@@ -255,7 +257,7 @@ RSpec.describe OpenHAB::DSL do
         expect((f - 2).format("%.1f %unit%")).to eq "19.1 °C"
         expect((c + f).format("%.1f %unit%")).to eq "61.9 °C"
         expect(f - 2 < 20).to be true
-        expect(2 + c).to eq 25
+        expect(40 - f < 2).to be true
         expect(2 + c == 25).to be true
         expect(c + 2 == 25).to be true
         expect([c, f, 2].min).to be 2
@@ -266,15 +268,18 @@ RSpec.describe OpenHAB::DSL do
       # See https://github.com/openhab/openhab-core/pull/3792
       # Use a zero-based unit to have a consistent result across OH versions.
       w = 5 | "W"
+      kw = 5 | "kW"
       unit("W") do
+        # numeric rhs
         expect(w * 2 == 10).to be true
-        expect(((5 | "kW") * 2).format("%.0f %unit%")).to eq "10000 W"
+        expect((kw * 2).format("%.0f %unit%")).to eq "10000 W"
         expect(w / 5).to eql 1 | "W"
-        # TODO: Support scalar lhs
-        # expect(2 * w).to eq 10
-        # expect(2 * w == 10).to be true
-        # expect(5 / w).to eql 1 | "W"
-        # expect((2 * w / 2)).to eql 5 # two_w.multiply(w).divide(two_w)
+        # numeric lhs
+        expect(2 * w).to eql 10 | "W"
+        expect((2 * kw).to_i).to eq 10_000
+        expect(2 * w == 10).to be true
+        expect(5 / w).to eql 1 | "W"
+        expect((2 * w / 2)).to eql w
       end
     end
 

--- a/spec/openhab/dsl_spec.rb
+++ b/spec/openhab/dsl_spec.rb
@@ -246,17 +246,18 @@ RSpec.describe OpenHAB::DSL do
       f = 70 | "°F"
       unit("°F") do
         expect(c - f < 4).to be true
-        expect(c - (24 | "°C") < 4).to be true
-        expect(QuantityType.new("24 °C") - c < 4).to be true
+        expect(c - (24 | "°C") < 32).to be true
+        expect(QuantityType.new("24 °C") - c < 34).to be true
       end
 
       unit("°C") do
         expect(f - (20 | "°C") < 2).to be true
         expect((f - 2).format("%.1f %unit%")).to eq "19.1 °C"
-        expect((c + f).format("%.1f %unit%")).to eq "44.1 °C"
+        expect((c + f).format("%.1f %unit%")).to eq "61.9 °C"
         expect(f - 2 < 20).to be true
+        expect(2 + c).to eq 25
         expect(2 + c == 25).to be true
-        expect((2 * (f + c) / 2) < 45).to be true
+        expect(c + 2 == 25).to be true
         expect([c, f, 2].min).to be 2
       end
 
@@ -266,7 +267,14 @@ RSpec.describe OpenHAB::DSL do
       # Use a zero-based unit to have a consistent result across OH versions.
       w = 5 | "W"
       unit("W") do
-        expect(2 * w == 10).to be true
+        expect(w * 2 == 10).to be true
+        expect(((5 | "kW") * 2).format("%.0f %unit%")).to eq "10000 W"
+        expect(w / 5).to eql 1 | "W"
+        # TODO: Support scalar lhs
+        # expect(2 * w).to eq 10
+        # expect(2 * w == 10).to be true
+        # expect(5 / w).to eql 1 | "W"
+        # expect((2 * w / 2)).to eql 5 # two_w.multiply(w).divide(two_w)
       end
     end
 

--- a/spec/openhab/dsl_spec.rb
+++ b/spec/openhab/dsl_spec.rb
@@ -256,9 +256,17 @@ RSpec.describe OpenHAB::DSL do
         expect((c + f).format("%.1f %unit%")).to eq "44.1 °C"
         expect(f - 2 < 20).to be true
         expect(2 + c == 25).to be true
-        expect(2 * c == 46).to be true
         expect((2 * (f + c) / 2) < 45).to be true
         expect([c, f, 2].min).to be 2
+      end
+
+      # The behavior of Multiplications and Divisions with non zero-based units such as °C and °F
+      # (as opposed to Kelvin) is different between OH 4.1 and previous versions.
+      # See https://github.com/openhab/openhab-core/pull/3792
+      # Use a zero-based unit to have a consistent result across OH versions.
+      w = 5 | "W"
+      unit("W") do
+        expect(2 * w == 10).to be true
       end
     end
 


### PR DESCRIPTION
This PR addressed the following problems:
1. Operates under the rhs unit
```
a = QuantityType.new("20 °C")
b = QuantityType.new("9 °F")
logger.warn a + b # => 45 °F - this should be 25 °C 
logger.warn b + a # => 25 °C - this should be 45 °F
```
self gets converted to other's unit + other converted to self.unit then added to self. This gave the wrong result in the wrong unit.

The lhs just needs to be converted to the unit defined by the block, and rhs needs to be converted using `to_unit_relative` to the unit defined by the block.

2. Inside a unit block
```
a = QuantityType.new("20 °C")
b = QuantityType.new("9 °F")
unit("°C") do
  logger.warn a + b # => 7.2222 °C => This should be 25 °C
  logger.warn b + a # => 7.2222 °C => correct. 9 °F + 20 °C -> -12.78 °C + 20 °C
  logger.warn 2 + b # -> - 20.999 °F => Should be 2°C + 5°C = 7 °C
  logger.warn 2 - b # => 24.999 °F => Should be 2 - 5 = -3 °C
end
```

3. Multiplications inside a unit block didn't take up the block's unit
```
kw = 5 | "kW"
unit("W") do
  logger.warn (kw * 2).format("%.0f %unit%") # => 10 kW => Should turn into 10000 W
  logger.warn (2 * kw).format("%.0f %unit%") # => 10 kW => Should turn into 10000 W
end
```

4. +/- against non-quantity type is still allowed. It takes up the other operand's unit. This should raise an exception instead.
```
kw = 5 | "kW"
logger.warn kw + 5 # => 10kW
logger.warn 5 + kw # => java.lang.NullPointerException: Cannot read field "quantity" because "state" is null
```

5. Fix failing specs due to core changes in https://github.com/openhab/openhab-core/pull/3792
