### PR TITLE
Use block's source location as timer's log identifier

### DIFF
--- a/lib/openhab/core/timer.rb
+++ b/lib/openhab/core/timer.rb
@@ -49,7 +49,8 @@ module OpenHAB
         @id = id
         @thread_locals = thread_locals
         @block = block
-        @timer = ScriptExecution.create_timer(1.minute.from_now) { execute }
+        timer_identifier = block.source_location.join(":")
+        @timer = ScriptExecution.create_timer(timer_identifier, 1.minute.from_now) { execute }
         reschedule!(@time)
       end
 


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/2911

just so the block location shows up in log. Instead of `<unknown>`
```
12:55:46.968 [WARN ] [core.internal.scheduler.SchedulerImpl] - Scheduled job '<unknown>' failed and stopped
org.jruby.exceptions.RuntimeError: (RuntimeError) 
        at RUBY.<main>(/openhab/conf/automation/ruby/rules/test2.rb:1) ~[?:?]
```

It would log as:
```
13:06:14.784 [WARN ] [core.internal.scheduler.SchedulerImpl] - Scheduled job '/openhab/conf/automation/ruby/rules/test2.rb:1' failed and stopped
org.jruby.exceptions.RuntimeError: (RuntimeError) 
        at RUBY.<main>(/openhab/conf/automation/ruby/rules/test2.rb:1) ~[?:?]
```

We could also allow for specifying a custom identifier but it doesn't have much use beyond the error message in the log.