### PR TITLE
Allow symbolic channel name in ItemBuilder

### DIFF
--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -259,9 +259,10 @@ module OpenHAB
         #        Fluent alias for `tag`.
         # @param autoupdate [true, false, nil] Autoupdate setting (see {ItemBuilder#autoupdate})
         # @param thing [String, Core::Things::Thing, Core::Things::ThingUID, nil]
-        #   A Thing to be used as the base for the channel
-        # @param channel [String, Core::Things::ChannelUID, nil] Channel to link the item to
-        # @param expire [String] An expiration specification.
+        #   A Thing to be used as the base for the channel.
+        # @param channel [String, Core::Things::ChannelUID, nil]
+        #   Channel to link the item to (see {ItemBuilder#channel}).
+        # @param expire [String] An expiration specification (see {ItemBuilder#expire}).
         # @param alexa [String, Symbol, Array<(String, Hash<String, Object>)>, nil]
         #   Alexa metadata (see {ItemBuilder#alexa})
         # @param ga [String, Symbol, Array<(String, Hash<String, Object>)>, nil]
@@ -413,7 +414,9 @@ module OpenHAB
         #
         # Add a channel link to this item.
         #
-        # @param config [Hash] Additional configuration, such as profile
+        # @param [String, Core::Things::ChannelUID, Symbol] channel Channel to link the item to.
+        #   When thing is set, this can be a relative channel name.
+        # @param [Hash] config Additional configuration, such as profile
         # @return [void]
         #
         # @example
@@ -423,7 +426,13 @@ module OpenHAB
         #     end
         #   end
         #
+        # @example Relative channel name
+        #   items.build do
+        #     switch_item Bedroom_Light, thing: "mqtt:topic:bedroom-light", channel: :power
+        #   end
+        #
         def channel(channel, config = {})
+          channel = channel.to_s
           channel = "#{@thing}:#{channel}" if @thing && !channel.include?(":")
           @channels << [channel, config]
         end

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -181,7 +181,7 @@ module OpenHAB
         # @return [String, nil]
         attr_accessor :format
         # The icon to be associated with the item
-        # @return [Symbol, nil]
+        # @return [Symbol, String, nil]
         attr_accessor :icon
         # Groups to which this item should be added
         # @return [Array<String, GroupItem>]
@@ -240,7 +240,7 @@ module OpenHAB
         # @param dimension [Symbol, nil] The unit dimension for a {NumberItem} (see {ItemBuilder#dimension})
         # @param unit [Symbol, String, nil] The unit for a {NumberItem} (see {ItemBuilder#unit})
         # @param format [String, nil] The formatting pattern for the item's state (see {ItemBuilder#format})
-        # @param icon [Symbol, nil] The icon to be associated with the item (see {ItemBuilder#icon})
+        # @param icon [Symbol, String, nil] The icon to be associated with the item (see {ItemBuilder#icon})
         # @param group [String,
         #   GroupItem,
         #   GroupItemBuilder,
@@ -260,7 +260,7 @@ module OpenHAB
         # @param autoupdate [true, false, nil] Autoupdate setting (see {ItemBuilder#autoupdate})
         # @param thing [String, Core::Things::Thing, Core::Things::ThingUID, nil]
         #   A Thing to be used as the base for the channel.
-        # @param channel [String, Core::Things::ChannelUID, nil]
+        # @param channel [String, Symbol, Core::Things::ChannelUID, Core::Things::Channel, nil]
         #   Channel to link the item to (see {ItemBuilder#channel}).
         # @param expire [String] An expiration specification (see {ItemBuilder#expire}).
         # @param alexa [String, Symbol, Array<(String, Hash<String, Object>)>, nil]
@@ -414,9 +414,9 @@ module OpenHAB
         #
         # Add a channel link to this item.
         #
-        # @param [String, Core::Things::ChannelUID, Symbol] channel Channel to link the item to.
-        #   When thing is set, this can be a relative channel name.
-        # @param [Hash] config Additional configuration, such as profile
+        # @param channel [String, Symbol, Core::Things::ChannelUID, Core::Things::Channel]
+        #   Channel to link the item to. When thing is set, this can be a relative channel name.
+        # @param config [Hash] Additional configuration, such as profile
         # @return [void]
         #
         # @example

--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -176,10 +176,11 @@ module OpenHAB
 
         # Add an explicitly configured channel to this item
         # @see ChannelBuilder#initialize
+        # @return [Core::Things::Channel]
         def channel(*args, **kwargs, &block)
           channel = ChannelBuilder.new(*args, thing: self, **kwargs)
           channel.instance_eval(&block) if block
-          @channels << channel.build
+          channel.build.tap { |c| @channels << c }
         end
 
         # @!visibility private

--- a/spec/openhab/dsl/items/builder_spec.rb
+++ b/spec/openhab/dsl/items/builder_spec.rb
@@ -360,6 +360,15 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
       expect(StringItem1.thing).to be things["astro:sun:home"]
     end
 
+    it "can use symbolic channel" do
+      items.build do
+        string_item "StringItem1", thing: "astro:sun:home" do
+          channel :"season#name"
+        end
+      end
+      expect(StringItem1.thing).to be things["astro:sun:home"]
+    end
+
     it "ignores thing when channel contains multiple segments" do
       items.build do
         string_item "StringItem1", thing: "foo:baz:bar", channel: "astro:sun:home:season#name"


### PR DESCRIPTION
Since we allow symbolic channel name in channel builder, this also allows it in item builder.

```ruby
things.build do
  thing "xxx" do
    channel :channelname, "string"
  end
end

items.build do
  string_item MyItem, thing: "xxx" do
    channel :channelname
  end
end
```