### PR TITLE
Allow updating things/items/sitemaps by recreating them

### DIFF
--- a/lib/openhab/core/emulate_hash.rb
+++ b/lib/openhab/core/emulate_hash.rb
@@ -103,7 +103,12 @@ module OpenHAB
       def merge!(*others, &block)
         return self if others.empty?
 
-        replace(merge(*others, &block))
+        # don't call replace here so we don't touch other keys
+        others.shift.merge(*others, &block).each do |key, value|
+          value = yield key, self[key], value if key?(key) && block
+          store(key, value)
+        end
+        self
       end
       alias_method :update, :merge!
 

--- a/lib/openhab/core/items/group_item.rb
+++ b/lib/openhab/core/items/group_item.rb
@@ -106,6 +106,9 @@ module OpenHAB
           alias_method :to_s, :inspect
         end
 
+        # @!attribute [r] function
+        # @return [GroupFunction] Returns the function of this GroupItem
+
         # Override because we want to send them to the base item if possible
         %i[command update].each do |method|
           define_method(method) do |command|
@@ -150,6 +153,19 @@ module OpenHAB
               base_item&.is_a?(#{type_class}Item)  #   base_item&.is_a?(DateTimeItem)
             end                                    # end
           RUBY
+        end
+
+        #
+        # Compares all attributes of the item with another item.
+        #
+        # @param other [Item] The item to compare with
+        # @return [true,false] true if all attributes are equal, false otherwise
+        #
+        # @!visibility private
+        def config_eql?(other)
+          return false unless super
+
+          base_item&.type == other.base_item&.type && function&.inspect == other.function&.inspect
         end
 
         private

--- a/lib/openhab/core/items/number_item.rb
+++ b/lib/openhab/core/items/number_item.rb
@@ -48,6 +48,11 @@ module OpenHAB
           super
         end
 
+        # @!visibility private
+        def config_eql?(other)
+          super && dimension == other.dimension
+        end
+
         protected
 
         # Adds the unit dimension

--- a/lib/openhab/core/items/registry.rb
+++ b/lib/openhab/core/items/registry.rb
@@ -45,13 +45,19 @@ module OpenHAB
         # Enter the Item Builder DSL.
         #
         # @param (see Core::Provider.current)
+        # @param update [true, false]  Update existing items with the same name.
+        #   When false, an error will be raised if an item with the same name already exists.
         # @yield Block executed in the context of a {DSL::Items::Builder}
         # @return [Object] The return value of the block.
+        # @raise [ArgumentError] if an item with the same name already exists and `update` is false.
+        # @raise [FrozenError] if `update` is true but the existing item with the same name
+        #   wasn't created by the current provider.
         #
         # @see DSL::Items::Builder
         #
-        def build(preferred_provider = nil, &block)
-          DSL::Items::BaseBuilderDSL.new(preferred_provider).instance_eval_with_dummy_items(&block)
+        def build(preferred_provider = nil, update: true, &block)
+          DSL::Items::BaseBuilderDSL.new(preferred_provider, update: update)
+                                    .instance_eval_with_dummy_items(&block)
         end
 
         #

--- a/lib/openhab/core/registry.rb
+++ b/lib/openhab/core/registry.rb
@@ -30,9 +30,7 @@ module OpenHAB
           # So take an extra step to verify that the provider really holds the given instance.
           # by using equal? to compare the object's identity.
           # Only ManagedProviders have a #get method to look up the object by uid.
-          if !provider.is_a?(org.openhab.core.common.registry.ManagedProvider) || provider.get(key.uid).equal?(key)
-            provider
-          end
+          provider if !provider.is_a?(ManagedProvider) || provider.get(key.uid).equal?(key)
         elsif (element = identifierToElement[key])
           elementToProvider[element]
         end

--- a/lib/openhab/core/registry.rb
+++ b/lib/openhab/core/registry.rb
@@ -20,12 +20,22 @@ module OpenHAB
       def provider_for(key)
         elementReadLock.lock
         if key.is_a?(org.openhab.core.common.registry.Identifiable)
-          element = key
-        else
-          return nil unless (element = identifierToElement[key])
-        end
+          return unless (provider = elementToProvider[key])
 
-        elementToProvider[element]
+          # The HashMap lookup above uses java's hashCode() which has been overridden
+          # by GenericItem and ThingImpl to return object's uid, e.g. item's name, thing uid
+          # so it will return a provider even for an unmanaged object having the same uid
+          # as an existing managed object.
+
+          # So take an extra step to verify that the provider really holds the given instance.
+          # by using equal? to compare the object's identity.
+          # Only ManagedProviders have a #get method to look up the object by uid.
+          if !provider.is_a?(org.openhab.core.common.registry.ManagedProvider) || provider.get(key.uid).equal?(key)
+            provider
+          end
+        elsif (element = identifierToElement[key])
+          elementToProvider[element]
+        end
       ensure
         elementReadLock.unlock
       end

--- a/lib/openhab/core/sitemaps/provider.rb
+++ b/lib/openhab/core/sitemaps/provider.rb
@@ -57,6 +57,7 @@ module OpenHAB
         #
         # Enter the Sitemap Builder DSL.
         #
+        # @param update [true, false]  When true, existing sitemaps with the same name will be updated.
         # @yield Block executed in the context of a {DSL::Sitemaps::Builder}
         # @return [void]
         #
@@ -82,8 +83,8 @@ module OpenHAB
         #     end
         #   end
         #
-        def build(&block)
-          DSL::Sitemaps::Builder.new(self).instance_eval(&block)
+        def build(update: true, &block)
+          DSL::Sitemaps::Builder.new(self, update: update).instance_eval(&block)
         end
         # rubocop:enable Layout/LineLength
 
@@ -123,7 +124,7 @@ module OpenHAB
           @listeners.each { |l| l.model_changed(element.name, org.openhab.core.model.core.EventType::REMOVED) }
         end
 
-        def notify_listeners_about_updated_element(element)
+        def notify_listeners_about_updated_element(_old_element, element)
           @listeners.each { |l| l.model_changed(element.name, org.openhab.core.model.core.EventType::MODIFIED) }
         end
       end

--- a/lib/openhab/core/things/links/provider.rb
+++ b/lib/openhab/core/things/links/provider.rb
@@ -24,13 +24,11 @@ module OpenHAB
             end
 
             # @!visibility private
-            def link(item, channel, config = {})
+            def create_link(item, channel, config = {})
               config = Configuration.new(config.transform_keys(&:to_s))
               channel = ChannelUID.new(channel) if channel.is_a?(String)
               channel = channel.uid if channel.is_a?(Channel)
-              link = org.openhab.core.thing.link.ItemChannelLink.new(item.name, channel, config)
-
-              current.add(link)
+              org.openhab.core.thing.link.ItemChannelLink.new(item.name, channel, config)
             end
           end
 

--- a/lib/openhab/core/things/registry.rb
+++ b/lib/openhab/core/things/registry.rb
@@ -39,11 +39,17 @@ module OpenHAB
         #
         # Enter the Thing Builder DSL.
         # @param (see Core::Provider.current)
+        # @param update [true, false]
+        #   When true, existing things with the same name will be redefined if they're different.
+        #   When false, an error will be raised if a thing with the same uid already exists.
         # @yield Block executed in the context of a {DSL::Things::Builder}.
         # @return [Object] The result of the block.
+        # @raise [ArgumentError] if a thing with the same uid already exists and `update` is false.
+        # @raise [FrozenError] if `update` is true but the existing thing with the same uid
+        #   wasn't created by the current provider.
         #
-        def build(preferred_provider = nil, &block)
-          DSL::Things::Builder.new(preferred_provider).instance_eval(&block)
+        def build(preferred_provider = nil, update: true, &block)
+          DSL::Things::Builder.new(preferred_provider, update: update).instance_eval(&block)
         end
 
         #

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -198,6 +198,16 @@ module OpenHAB
         end
 
         #
+        # Compares all attributes of the thing with another thing.
+        #
+        # @param other [Thing] The thing to compare with
+        # @return [true,false] true if all attributes are equal, false otherwise
+        #
+        def config_eql?(other)
+          %i[uid label channels bridge_uid location configuration].all? { |method| send(method) == other.send(method) }
+        end
+
+        #
         # Delegate missing methods to the thing's default actions scope.
         #
         # @example

--- a/lib/openhab/dsl/sitemaps/builder.rb
+++ b/lib/openhab/dsl/sitemaps/builder.rb
@@ -12,8 +12,9 @@ module OpenHAB
       # Base sitemap builder DSL
       class Builder
         # @!visibility private
-        def initialize(provider)
+        def initialize(provider, update:)
           @provider = provider
+          @update = update
         end
 
         # (see SitemapBuilder#initialize)
@@ -23,8 +24,12 @@ module OpenHAB
         def sitemap(name, label = nil, icon: nil, &block)
           sitemap = SitemapBuilder.new(name, label, icon: icon)
           sitemap.instance_eval_with_dummy_items(&block) if block
-          @provider.add(sitemap.build)
-          sitemap
+          sitemap = sitemap.build
+          if @update && @provider.get(sitemap.uid)
+            @provider.update(sitemap)
+          else
+            @provider.add(sitemap)
+          end
         end
       end
 

--- a/spec/openhab/core/items/registry_spec.rb
+++ b/spec/openhab/core/items/registry_spec.rb
@@ -28,5 +28,11 @@ RSpec.describe OpenHAB::Core::Items::Registry do
     it "works" do
       expect(SwitchTwo.provider).to be_a OpenHAB::Core::Items::Provider
     end
+
+    it "returns nil for items that aren't registered" do
+      expect(SwitchTwo.provider).not_to be_nil
+      unmanaged_item = OpenHAB::DSL::Items::ItemBuilder.item_factory.create_item("Switch", "SwitchTwo")
+      expect(unmanaged_item.provider).to be_nil
+    end
   end
 end

--- a/spec/openhab/dsl/sitemaps/builder_spec.rb
+++ b/spec/openhab/dsl/sitemaps/builder_spec.rb
@@ -167,4 +167,16 @@ RSpec.describe OpenHAB::DSL::Sitemaps::Builder do
       end
     end
   end
+
+  context "when redefining a sitemap" do
+    it "with update: false, complains if you try to create a sitemap with the same name" do
+      sitemaps.build(update: false) { sitemap "default" }
+      expect { sitemaps.build(update: false) { sitemap "default" } }.to raise_error(ArgumentError)
+    end
+
+    it "allows you to redefine a sitemap with the same name by default" do
+      sitemaps.build { sitemap "default" }
+      sitemaps.build { sitemap "default" }
+    end
+  end
 end

--- a/spec/openhab/dsl/things/builder_spec.rb
+++ b/spec/openhab/dsl/things/builder_spec.rb
@@ -10,6 +10,138 @@ RSpec.describe OpenHAB::DSL::Things::Builder do
     expect(home = things["astro:sun:home"]).not_to be_nil
     expect(home.channels["rise#event"]).not_to be_nil
     expect(home.configuration.get("geolocation")).to eq "0,0"
+    expect(home).to be_enabled
+  end
+
+  context "when things already exist and build is called" do
+    context "with update: false argument" do
+      it "complains if you try to create a thing with the same UID" do
+        uid = "a:b:c"
+        things.build { thing uid, "old label" }
+        expect { things.build(update: false) { thing uid, "new label" } }.to raise_error(ArgumentError)
+      end
+
+      it "fails creating the new thing but doesn't cause any changes in the original thing" do
+        uid = "a:b:c"
+        old_channel = nil
+        properties = {
+          bridge: "a:b:bridge_a",
+          location: "location_a",
+          config: { identity: "config_a" },
+          enabled: true
+        }.freeze
+        old_thing = things.build do
+          thing uid, "old label", **properties do
+            old_channel = channel "x", "string"
+          end
+        end
+
+        expect(things[uid].enabled?).to eql properties[:enabled]
+
+        expect do
+          things.build(update: false) do
+            thing uid,
+                  "new label",
+                  bridge: "a:b:bridge_b",
+                  location: "location_b",
+                  config: { identity: "config_b" },
+                  enabled: !properties[:enabled] do
+              channel "y", "number"
+            end
+          end
+        end.to raise_error(ArgumentError)
+        thing = things[uid]
+        expect(thing.label).to eql "old label"
+        expect(thing.__getobj__).to be old_thing.__getobj__
+        expect(thing.bridge_uid).to eq properties[:bridge]
+        expect(thing.location).to eq properties[:location]
+        expect(thing.configuration).to eq properties[:config]
+        expect(thing.enabled?).to eql properties[:enabled]
+        expect(thing.channels).to match_array(old_channel)
+      end
+    end
+
+    context "with default arguments (update: true)" do
+      subject(:thing) { things[uid] }
+
+      let(:uid) { "a:b:c" }
+
+      it "refuses to update an existing thing from a different provider" do
+        uid = "a:b:file-thing"
+        existing_thing = OpenHAB::DSL::Things::ThingBuilder.new(uid).build
+        allow(OpenHAB::DSL.things).to receive(:key?).with(uid).and_return(true)
+        allow(OpenHAB::DSL.things).to receive(:[]).with(uid).and_return(existing_thing)
+        expect { things.build { thing uid } }.to raise_error(FrozenError)
+      end
+
+      it "can create a new thing" do
+        things.build do
+          thing "astro:sun:home", "Astro Sun Data", config: { "geolocation" => "0,0" }
+        end
+        expect(home = things["astro:sun:home"]).not_to be_nil
+        expect(home.channels["rise#event"]).not_to be_nil
+        expect(home.configuration.get("geolocation")).to eq "0,0"
+      end
+
+      # @return [Array<OpenHAB::Core::Things::Thing, OpenHAB::Core::Things::Thing>]
+      #   An array of unproxied things [original, updated]
+      def build_and_update(org_config, new_config, thing_to_keep: :new_thing, &block)
+        org_config = org_config.dup
+        new_config = new_config.dup
+        default_uid = uid
+        org_thing = things.build do
+          thing(org_config.delete(:uid) || default_uid, org_config.delete(:label), **org_config)
+        end
+        # Unwrap the thing object now before creating the new thing.
+        # See the comment in items/builder_spec.rb for more details.
+        org_thing = org_thing.__getobj__
+        yield :original, org_thing if block
+
+        new_thing = things.build do
+          thing(new_config.delete(:uid) || default_uid, new_config.delete(:label), **new_config)
+        end
+        new_thing = new_thing.__getobj__
+        yield :updated, new_thing if block
+
+        case thing_to_keep
+        when :new_thing then expect(new_thing).not_to be org_thing
+        when :old_thing then expect(new_thing).to be org_thing
+        end
+
+        [org_thing, new_thing]
+      end
+
+      context "with changes" do
+        it "replaces the old thing when the label is different" do
+          build_and_update({ label: "Old Label" }, { label: "New Label" })
+          expect(thing.label).to eql "New Label"
+        end
+
+        it "replaces the old thing when the bridge is different" do
+          build_and_update({ bridge: "a:b:bridge_a" }, { bridge: "a:b:bridge_b" })
+          expect(thing.bridge_uid).to eq "a:b:bridge_b"
+        end
+
+        it "replaces the old thing when the location is different" do
+          build_and_update({ location: "location a" }, {})
+          expect(thing.location).to be_nil
+        end
+
+        it "replaces the old thing when the config is different" do
+          build_and_update({ config: { ipAddress: "1" } }, { config: { ipAddress: "2" } })
+          expect(thing.configuration[:ipAddress]).to eq "2"
+        end
+
+        it "keeps the old thing when nothing is different" do
+          build_and_update({}, {}, thing_to_keep: :old_thing)
+        end
+
+        it "keeps the old thing but update the state" do
+          build_and_update({}, { enabled: false }, thing_to_keep: :old_thing)
+          expect(thing).not_to be_enabled
+        end
+      end
+    end
   end
 
   it "can create a thing with separate binding and type params" do


### PR DESCRIPTION
Also includes some minor bug fixes
- notify_listeners_about_updated_element(_old_element, element) needed two parameters
- do an identity lookup for elementToProvider. Note, I tried `.to_h.compare_by_identity`, but it didn't do as expected. 
- It was possible to "add" new items/things/sitemaps that already existed when they were created by other providers.

Previously a newly created item will replace the existing one accidentally when calling `NewItem.label = "label"` during the building process. `#label=` calls `provider&.update` and because provider look up is based on item's uid (item name) it found a provider, and proceeded to update/replace the existing item with the new item. This happens even though the newly created item hadn't been officially added to the provider, and in fact the subsequent call to provider.add will fail because it already had an element with the same uid, but the new element is now the active one, despite the failure to add.

Random notes as I come to think of them about the implementation within this PR:
- ~~When updating an item, the old metadata doesn't get deleted.~~ It is now deleted.