### PR TITLE
Support expire configuration options in Item Builder

### DIFF
--- a/lib/openhab/core/items/metadata/hash.rb
+++ b/lib/openhab/core/items/metadata/hash.rb
@@ -13,6 +13,11 @@ module OpenHAB
         #
         # All keys are converted to strings.
         #
+        # As a special case, a #== comparison can be done against a [value, config] array.
+        # @example
+        #   MyItem.metadata[:namespace] = "value", { key: "value" }
+        #   MyItem.metadata[:namespace] == ["value", { "key" => "value" }] #=> true
+        #
         # @!attribute [rw] value
         #   @return [String] The main value for the metadata namespace.
         # @!attribute [r] namespace
@@ -149,6 +154,8 @@ module OpenHAB
               return configuration == other.configuration
             elsif value.empty? && other.respond_to?(:to_hash)
               return configuration == other.to_hash
+            elsif other.is_a?(Array)
+              return other == [value, configuration]
             end
             false
           end

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -429,10 +429,15 @@ module OpenHAB
         end
 
         #
-        # @!method expire(command: nil, state: nil)
+        # @!method expire(duration, command: nil, state: nil, ignore_state_updates: nil, ignore_commands: nil)
         #
         # Configure item expiration
         #
+        # @param duration [String, Duration, nil] Duration after which the command or state should be applied
+        # @param command [String, nil] Command to send on expiration
+        # @param state [String, nil] State to set on expiration
+        # @param ignore_state_updates [true, false] When true, state updates will not reset the expire timer
+        # @param ignore_commands [true, false] When true, commands will not reset the expire timer
         # @return [void]
         #
         # @example Get the current expire setting
@@ -448,7 +453,12 @@ module OpenHAB
         #   expire 5.minutes, state: NULL
         # @example Send a command on expiration
         #   expire 5.minutes, command: OFF
-        def expire(*args, command: nil, state: nil)
+        # @example Specify the duration and command in the same string
+        #   expire "5h,command=OFF"
+        # @example Set the expire configuration
+        #   expire 5.minutes, ignore_state_updates: true
+        #
+        def expire(*args, command: nil, state: nil, ignore_state_updates: nil, ignore_commands: nil)
           unless (0..2).cover?(args.length)
             raise ArgumentError,
                   "wrong number of arguments (given #{args.length}, expected 0..2)"
@@ -463,9 +473,14 @@ module OpenHAB
 
           duration = duration.to_s[2..].downcase if duration.is_a?(Duration)
           state = "'#{state}'" if state.respond_to?(:to_str) && type == :string
-          @expire = duration
-          @expire += ",state=#{state}" if state
-          @expire += ",command=#{command}" if command
+
+          value = duration
+          value += ",state=#{state}" if state
+          value += ",command=#{command}" if command
+
+          config = { ignoreStateUpdates: ignore_state_updates, ignoreCommands: ignore_commands }
+          config.compact!
+          @expire = [value, config]
         end
 
         # @!attribute [w] unit

--- a/spec/openhab/dsl/items/builder_spec.rb
+++ b/spec/openhab/dsl/items/builder_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
       switch_item "MySwitch2", expire: "2h"
       switch_item "MySwitch3", expire: [3.hours, OFF]
       switch_item "MySwitch4", expire: ["4h", { command: OFF }]
+      switch_item "MySwitch5", expire: ["4h", { ignore_state_updates: true }]
       string_item "MyString", expire: [5.hours, "EXPIRED"]
     end
 
@@ -164,6 +165,7 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
     expect(MySwitch2.metadata["expire"]&.value).to eq "2h"
     expect(MySwitch3.metadata["expire"]&.value).to eq "3h,state=OFF"
     expect(MySwitch4.metadata["expire"]&.value).to eq "4h,command=OFF"
+    expect(MySwitch5.metadata["expire"]).to eq ["4h", { "ignoreStateUpdates" => true }]
     expect(MyString.metadata["expire"]&.value).to eq "5h,state='EXPIRED'"
   end
 


### PR DESCRIPTION
`expire` can accept `ignoreStateUpdates` and `ignoreCommands` options

```ruby
items.build do
  switch_item Switch1, expire: [5.seconds, { ignore_state_updates: true }]

  switch_item Switch2 do
    expire 5.seconds, ignore_commands: true
  end

  config = { 
    expire: [5.seconds, { ignore_commands: true }], 
  }
  switch_item Switch3, **config
end
```
