### PR TITLE
Fix a non-array passed to item's `groups` argument inside group block

### DIFF
--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -591,7 +591,7 @@ module OpenHAB
 
           class_eval <<~RUBY, __FILE__, __LINE__ + 1
             def #{m}(*args, groups: nil, **kwargs)  # def dimmer_item(*args, groups: nil, **kwargs)
-              groups ||= []                         #   groups ||= []
+              groups = Array.wrap(groups)           #   groups = Array.wrap(groups)
               groups << self                        #   groups << self
               super                                 #   super
             end                                     # end

--- a/spec/openhab/dsl/items/builder_spec.rb
+++ b/spec/openhab/dsl/items/builder_spec.rb
@@ -31,12 +31,14 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
       group_item "MyGroupItem" do
         switch_item "MySwitchItem"
         switch_item "MySwitch2", groups: [Group1]
+        switch_item "MySwitch3", groups: Group1
       end
     end
 
-    expect(MyGroupItem.members.to_a).to match_array [MySwitchItem, MySwitch2]
+    expect(MyGroupItem.members.to_a).to match_array [MySwitchItem, MySwitch2, MySwitch3]
     expect(MySwitchItem.groups).to eq [MyGroupItem]
     expect(MySwitch2.groups).to match_array [Group1, MyGroupItem]
+    expect(MySwitch3.groups).to match_array [Group1, MyGroupItem]
   end
 
   it "can add items to groups" do


### PR DESCRIPTION
Since `groups` is advertised as a fluent alias for `group`, one should be able to pass a single group item (not an array of groups) to `groups` like this:

```ruby
items.build do
  number_item Test1, groups: gMyGroup
end
```
This worked fine.

The bug is when it's done inside a group_item's block
```ruby
items.build do
  group_item MyGroup do
    number_item Test1, groups: SomeOtherGroup
  end
end
```
Suddenly SomeOtherGroup will receive commands because inside GroupItemBuilder it does `groups << self` expecting that it's an array when it isn't. We need to wrap the variable `groups` in an array if it isn't one.

