### PR TITLE
Split Metadata::Hash#provider to provider and provider!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,8 @@ RSpec/NestedGroups:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
+RSpec/SubjectStub:
+  Enabled: false
 
 Style/CaseEquality:
   Exclude: # we're explicitly testing this operator

--- a/lib/openhab/core/items/item.rb
+++ b/lib/openhab/core/items/item.rb
@@ -281,7 +281,7 @@ module OpenHAB
           "#{s}>"
         end
 
-        # @return [org.openhab.core.common.registry.Provider]
+        # @return [org.openhab.core.common.registry.Provider, nil]
         def provider
           Provider.registry.provider_for(self)
         end

--- a/spec/openhab/core/items/metadata/hash_spec.rb
+++ b/spec/openhab/core/items/metadata/hash_spec.rb
@@ -90,4 +90,26 @@ RSpec.describe OpenHAB::Core::Items::Metadata::Hash do
       expect(namespace.to_h).to eql({ "qux" => "quux" })
     end
   end
+
+  describe "#provider" do
+    it "returns nil for unattached hashes" do
+      expect(OpenHAB::Core::Items::Metadata::Hash.from_value("namespace", "value").provider).to be_nil
+    end
+  end
+
+  describe "#provider!" do
+    it "returns the current provider for unattached hashes" do
+      expect(OpenHAB::Core::Items::Metadata::Hash.from_value("namespace", "value").provider!)
+        .to eq OpenHAB::Core::Items::Metadata::Provider.current
+    end
+
+    it "raises FrozenError if the provider is a generic provider" do
+      generic_provider = OpenHAB::Core::Items::Metadata::Provider.registry
+                                                                 .providers
+                                                                 .grep_v(OpenHAB::Core::ManagedProvider)
+                                                                 .first
+      allow(namespace).to receive(:provider).and_return(generic_provider)
+      expect { namespace.provider! }.to raise_error(FrozenError)
+    end
+  end
 end

--- a/spec/openhab/rspec/helpers_spec.rb
+++ b/spec/openhab/rspec/helpers_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe OpenHAB::RSpec::Helpers do
                                                automation/filea.sl20.rb
                                                automation/sl30/fileb.rb])
 
-      # rubocop:disable RSpec/SubjectStub
       expect(subject).to receive(:load).with("automation/filea.sl20.rb").ordered
       expect(subject).to receive(:load).with("automation/sl30/fileb.rb").ordered
       expect(subject).to receive(:load).with("automation/sl30/filec.rb").ordered


### PR DESCRIPTION
Fixes #161

So that the plain form acts like it does on other objects... simply returning the current provider (even if not managed), or nil if it doesn't actually exist yet.