### PR TITLE
Fix latitude/longitude/altitude getters on Location objects

### DIFF
--- a/lib/openhab/core/types/point_type.rb
+++ b/lib/openhab/core/types/point_type.rb
@@ -80,19 +80,19 @@ module OpenHAB
         # @!attribute [r] latitude
         # @return [QuantityType]
         def latitude
-          QuantityType.new(raw_latitude.to_big_decimal, SIUnits::DEGREE_ANGLE)
+          QuantityType.new(raw_latitude.to_big_decimal, Units::DEGREE_ANGLE)
         end
 
         # @!attribute [r] longitude
         # @return [QuantityType]
         def longitude
-          QuantityType.new(raw_longitude.to_big_decimal, SIUnits::DEGREE_ANGLE)
+          QuantityType.new(raw_longitude.to_big_decimal, Units::DEGREE_ANGLE)
         end
 
         # @!attribute [r] altitude
         # @return [QuantityType]
         def altitude
-          QuantityType.new(raw_altitude.to_big_decimal, Units::METRE)
+          QuantityType.new(raw_altitude.to_big_decimal, SIUnits::METRE)
         end
 
         #


### PR DESCRIPTION
This was due to a Units vs SIUnits confusion that other parts of this file however handled correctly.

Fixes issue #173
Signed-off-by: Ulrich Spörlein <uspoerlein@gmail.com>