### PR TITLE
Support all attributes of channel builder

### DIFF
--- a/lib/openhab/core/things/channel.rb
+++ b/lib/openhab/core/things/channel.rb
@@ -47,6 +47,34 @@ module OpenHAB
         def to_s
           uid.to_s
         end
+
+        # @deprecated OH3.4 this whole section is not needed in OH4+. Also see Thing#config_eql?
+        if Gem::Version.new(Core::VERSION) < Gem::Version.new("4.0.0")
+          # @!visibility private
+          module ChannelComparable
+            # @!visibility private
+            # This is only needed in OH3 because it is implemented in OH4 core
+            def ==(other)
+              return true if equal?(other)
+              return false unless other.is_a?(Channel)
+
+              %i[class
+                 uid
+                 label
+                 description
+                 kind
+                 channel_type_uid
+                 configuration
+                 properties
+                 default_tags
+                 auto_update_policy
+                 accepted_item_type].all? do |attr|
+                send(attr) == other.send(attr)
+              end
+            end
+          end
+          org.openhab.core.thing.binding.builder.ChannelBuilder.const_get(:ChannelImpl).prepend(ChannelComparable)
+        end
       end
     end
   end

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -204,7 +204,9 @@ module OpenHAB
         # @return [true,false] true if all attributes are equal, false otherwise
         #
         def config_eql?(other)
-          %i[uid label channels bridge_uid location configuration].all? { |method| send(method) == other.send(method) }
+          # @deprecated OH3.4 - in OH4, channels can be included in the array and do not need to be compared separately
+          channels.to_a == other.channels.to_a &&
+            %i[uid label bridge_uid location configuration].all? { |method| send(method) == other.send(method) }
         end
 
         #


### PR DESCRIPTION
Note, some (all?) bindings provide default values for some channel attributes, e.g. `acceptedItemType`, `label`, etc. when they are not specified. This will cause thing builder to update/replace the created thing instead of leaving it unchanged. The update will cause the Thing status will change to OFFLINE, then back ONLINE.

By specifying those values during the channel creation, the Thing builder will see that the new Thing being built is exactly the same as the existing Thing, and will not update the existing thing, thereby avoiding the change in Thing status.

Demonstration:

```ruby
things.build do
  thing "mqtt:topic:mything", broker: "mqtt:broker:mybroker" do
    channel "signal", "number", config: { stateTopic: "xxxx" }
  end
end
# Once built, the binding will set a default label and acceptedItemType

... 
# Try to recreate, Thing will be updated because the specified channel attributes are "different" from the existing thing
things.build do
  thing "mqtt:topic:mything", broker: "mqtt:broker:mybroker" do
    channel "signal", "number", config: { stateTopic: "xxxx" }
  end
end
```

MQTT will add a default label and acceptedItemType: "Number" to the above channel, so when we try to recreate it again, the thing builder noticed that the channels have different attributes, so the builder will update the Thing instead of leaving it alone.

To avoid this problem:

```ruby
things.build do
  thing "mqtt:topic:mything", broker: "mqtt:broker:mybroker" do
    channel "signal", "number", "custom label", config: { stateTopic: "xxxx" }, accepted_item_type: "Number"
  end
end

... 
# Try to recreate, Thing will not need to be updated because now all attributes match
things.build do
  thing "mqtt:topic:mything", broker: "mqtt:broker:mybroker" do
    channel "signal", "number", "custom label", config: { stateTopic: "xxxx" }, accepted_item_type: "Number"
  end
end
```