### PR TITLE
Add Item.link, Item.unlink, and Item.links.clear to add/remove a link to a channel

### DIFF
--- a/lib/openhab/core/items/item_channel_links.rb
+++ b/lib/openhab/core/items/item_channel_links.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module OpenHAB
+  module Core
+    module Items
+      #
+      # A wrapper for {Item#links} delegated to Set<{org.openhab.core.thing.link.ItemChannelLink}>.
+      #
+      # Adds methods for clearing item's links to channels.
+      #
+      class ItemChannelLinks < SimpleDelegator
+        #
+        # @param [Item] item The item that the links belong to
+        # @param [Set<ItemChannelLink>] links The set of links to delegate to
+        #
+        # @!visibility private
+        def initialize(item, links)
+          super(links)
+          @item = item
+        end
+
+        #
+        # Removes all links to channels from managed link providers.
+        # @return [self]
+        #
+        def clear
+          Things::Links::Provider.registry.all.each do |link|
+            next unless link.item_name == @item.name
+
+            provider = Things::Links::Provider.registry.provider_for(link.uid)
+            if provider.is_a?(ManagedProvider)
+              provider.remove(link.uid)
+            else
+              logger.warn("Cannot remove the link #{link.uid} from non-managed provider #{provider.inspect}")
+            end
+          end
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/core/things/channel_uid.rb
+++ b/lib/openhab/core/things/channel_uid.rb
@@ -42,8 +42,7 @@ module OpenHAB
         # @return [Array<Item>] An array of things or an empty array
         #
         def items
-          registry = OSGi.service("org.openhab.core.thing.link.ItemChannelLinkRegistry")
-          registry.get_linked_items(self).map { |i| Items::Proxy.new(i) }
+          Links::Provider.registry.get_linked_items(self).map { |i| Items::Proxy.new(i) }
         end
       end
     end

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -156,7 +156,6 @@ module OpenHAB
             item.update(builder.state) unless builder.state.nil?
 
             # make sure to add the item to the registry before linking it
-            provider = Core::Things::Links::Provider.current
             channel_uids = builder.channels.to_set do |(channel, config)|
               # fill in partial channel names from group's thing id
               if !channel.include?(":") &&
@@ -165,17 +164,11 @@ module OpenHAB
                 channel = "#{thing}:#{channel}"
               end
 
-              new_link = Core::Things::Links::Provider.create_link(item, channel, config)
-              if !(current_link = provider.get(new_link.uid))
-                provider.add(new_link)
-              elsif current_link.configuration != config
-                provider.update(new_link)
-              end
-
-              new_link.linked_uid
+              item.link(channel, config).linked_uid
             end
 
             # remove links not in the new item
+            provider = Core::Things::Links::Provider.current
             provider.all.each do |link|
               provider.remove(link.uid) if link.item_name == item.name && !channel_uids.include?(link.linked_uid)
             end


### PR DESCRIPTION
Adding/removing links on an item would be:

```ruby
MyItem.link("mqtt:topic:foo:channel")
MyItem.link("mqtt:topic:foo:channel", profile: "transform:MAP", function: "mytransform.map")
MyItem.link things["mqtt:topic:foo"].channels["channel"]

MyItem.unlink("mqtt:topic:foo:channel")
MyItem.links.clear
```

