### PR TITLE
Warn when creating a tag that already exists

### DIFF
--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -311,14 +311,17 @@ module OpenHAB
               synonyms = Array.wrap(synonyms).map { |s| s.to_s.strip }
 
               tags.map do |name, parent|
+                if (existing_tag = lookup(name))
+                  logger.warn("Tag already exists: #{existing_tag.inspect}")
+                  next
+                end
+
                 unless parent.is_a?(SemanticTag)
                   parent_tag = lookup(parent)
                   raise ArgumentError, "Unknown parent: #{parent}" unless parent_tag
 
                   parent = parent_tag
                 end
-
-                next if lookup(name)
 
                 new_tag = org.openhab.core.semantics.SemanticTagImpl.new("#{parent.uid}_#{name}",
                                                                          label,

--- a/spec/openhab/core/items/semantics_spec.rb
+++ b/spec/openhab/core/items/semantics_spec.rb
@@ -355,6 +355,12 @@ RSpec.describe OpenHAB::Core::Items::Semantics do
         expect(Semantics.lookup("Syn1")).to be Semantics::ArraySynonyms
         expect(Semantics.lookup("Syn2")).to be Semantics::ArraySynonyms
       end
+
+      it "warns when trying to create a tag that already exists" do
+        Semantics.add(ExistingTag: Semantics::Equipment)
+        expect(Semantics.logger).to receive(:warn).with(/already exists/)
+        Semantics.add(ExistingTag: Semantics::Point)
+      end
     end
 
     describe "#remove" do


### PR DESCRIPTION
Otherwise it gets confusing when trying to add a tag and it doesn't work as expected because a tag with the same name already exists and that tag has different attributes (parent, label, etc).