### PR TITLE
Fix ProfileCallback#handle_command when an item is linked to a different channel type

### DIFF
--- a/lib/openhab/core/things/item_channel_link.rb
+++ b/lib/openhab/core/things/item_channel_link.rb
@@ -26,6 +26,12 @@ module OpenHAB
           DSL.items[item_name]
         end
 
+        # @!attribute [r] channel
+        # @return [Channel]
+        def channel
+          DSL.things[linked_uid.thing_uid].channels[linked_uid.id]
+        end
+
         alias_method :channel_uid, :linked_uid
       end
     end

--- a/lib/openhab/core/things/profile_callback.rb
+++ b/lib/openhab/core/things/profile_callback.rb
@@ -8,44 +8,37 @@ module OpenHAB
       # and channels.
       #
       module ProfileCallback
-        class << self
-          #
-          # Wraps the parent class's method to format non-Types.
-          #
-          # @!macro def_state_parsing_method
-          #   @!method $1($2)
-          #   @return [void]
-          # @!visibility private
-          def def_state_parsing_method(method, param_name)
-            class_eval <<~RUBY, __FILE__, __LINE__ + 1
-              def #{method}(type)                                                             # def handle_command(type)
-                type = link.item.format_#{(param_name == :state) ? :update : param_name}(type)  #   type = link.item.format_command(type)
-                super(type)                                                                   #   super(type)
-              end                                                                             # end
-            RUBY
-          end
-        end
-
         #
         # Forward the given command to the respective thing handler.
         #
         # @param [Command] command
         #
-        def_state_parsing_method(:handle_command, :command)
+        def handle_command(command)
+          @dummy_channel_item ||= DSL::Items::ItemBuilder.item_factory.create_item(link.channel.accepted_item_type,
+                                                                                   "")
+          command = @dummy_channel_item.format_command(command)
+          super(command)
+        end
 
         #
         # Send a command to the framework.
         #
         # @param [Command] command
         #
-        def_state_parsing_method(:send_command, :command)
+        def send_command(command)
+          command = link.item.format_command(command)
+          super(command)
+        end
 
         #
         # Send a state update to the framework.
         #
         # @param [State] state
         #
-        def_state_parsing_method(:send_update, :state)
+        def send_update(state)
+          state = link.item.format_update(state)
+          super(state)
+        end
       end
     end
   end

--- a/spec/openhab/dsl_spec.rb
+++ b/spec/openhab/dsl_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe OpenHAB::DSL do
       MyString << "foo"
       expect(unit).to eql "°F"
     end
+
+    # Whilst sending a command to astro:sun:home:season#name does nothing, it's used here
+    # to test that it doesn't cause any errors due to formatting being done by ProfileCallback
+    it "supports sending a command to a channel that has a different type than the item" do
+      profile :season_color do |callback:|
+        callback.handle_command("test")
+        false
+      end
+
+      items.build do
+        color_item "SeasonColor", channel: ["astro:sun:home:season#name", { profile: "ruby:season_color" }]
+      end
+
+      SeasonColor << "0,100,100"
+    end
   end
 
   describe "#script" do


### PR DESCRIPTION
This failed because handle_command tried to call ColorItem#format_command when the channel is a String and should be able to handle any string, not related to a color

```ruby
profile("test") do |event, command:, callback:|
  logger.warn "Profile called #{event} #{command}"
  case event
  when :command_from_item
    logger.warn("command_from_item: #{command} #{command.class}")
    callback.handle_command("test")
  end
end

things.build do
  thing "astro:moon:test"
end

items.build do
  color_item "Color1" do
    channel "astro:moon:test:phase#name", profile: "ruby:test"
  end
end

Color1.command "0,100,100"
```