### PR TITLE
Add ensure_states! and bang version of command shortcuts

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -474,6 +474,9 @@ My_Item.ensure << ON
 logger.info("Turning off the light") if My_Item.ensure.off
 ```
 
+See {OpenHAB::DSL.ensure_states ensure_states}, {OpenHAB::DSL.ensure_states! ensure_states!},
+{OpenHAB::DSL::Items::Ensure::Ensurable.ensure ensure}.
+
 ##### Timed Commands <!-- omit from toc -->
 
 A {OpenHAB::DSL::Items::TimedCommand Timed Command} is similar to the openHAB Item's [expire parameter](https://www.openhab.org/docs/configuration/items.html#parameter-expire) but it offers more flexibility.

--- a/lib/openhab/core/items.rb
+++ b/lib/openhab/core/items.rb
@@ -65,13 +65,19 @@ module OpenHAB
               ruby2_keywords def #{command}(*args, &block)  # ruby2_keywords def on(*args, &block)
                 command(#{value}, *args, &block)            #   command(ON, *args, &block)
               end                                           # end
+              ruby2_keywords def #{command}!(*args, &block) # ruby2_keywords def on!(*args, &block)
+                command!(#{value}, *args, &block)           #   command!(ON, *args, &block)
+              end                                           # end
             RUBY
 
             logger.trace("Defining Enumerable##{command} for #{value}")
             Enumerable.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-              def #{command}        # def on
-                each(&:#{command})  #   each(&:on)
-              end                   # end
+              def #{command}         # def on
+                each(&:#{command})   #   each(&:on)
+              end                    # end
+              def #{command}!        # def on!
+                each(&:#{command}!)  #   each(&:on!)
+              end                    # end
             RUBY
 
             logger.trace("Defining ItemCommandEvent##{command}? for #{value}")

--- a/lib/openhab/core/items/dimmer_item.rb
+++ b/lib/openhab/core/items/dimmer_item.rb
@@ -133,6 +133,16 @@ module OpenHAB
         #   Send the {DECREASE} command to the item
         #   @return [DimmerItem] `self`
 
+        # @!method increase!
+        #   Send the {INCREASE} command to the item, even when
+        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [DimmerItem] `self`
+
+        # @!method decrease!
+        #   Send the {DECREASE} command to the item, even when
+        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [DimmerItem] `self`
+
         # raw numbers translate directly to PercentType, not a DecimalType
         # @!visibility private
         def format_type(command)

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -128,8 +128,11 @@ module OpenHAB
         # Send a command to this item
         #
         # When this method is chained after the {OpenHAB::DSL::Items::Ensure::Ensurable#ensure ensure}
-        # method, or issued inside an {OpenHAB::DSL.ensure_states ensure_states} block,
+        # method, or issued inside an {OpenHAB::DSL.ensure_states ensure_states} block, or after
+        # {OpenHAB::DSL.ensure_states! ensure_states!} have been called,
         # the command will only be sent if the item is not already in the same state.
+        #
+        # The similar method `command!`, however, will always send the command regardless of the item's state.
         #
         # @param [Command] command command to send to the item
         # @return [self, nil] nil when `ensure` is in effect and the item was already in the same state,
@@ -137,6 +140,7 @@ module OpenHAB
         #
         # @see DSL::Items::TimedCommand#command Timed Command
         # @see OpenHAB::DSL.ensure_states ensure_states
+        # @see OpenHAB::DSL.ensure_states! ensure_states!
         # @see DSL::Items::Ensure::Ensurable#ensure ensure
         #
         def command(command)
@@ -145,6 +149,7 @@ module OpenHAB
           $events.send_command(self, command)
           Proxy.new(self)
         end
+        alias_method :command!, :command
 
         # not an alias to allow easier stubbing and overriding
         def <<(command)
@@ -170,6 +175,7 @@ module OpenHAB
           $events.post_update(self, state)
           Proxy.new(self)
         end
+        alias_method :update!, :update
 
         # @!visibility private
         def format_command(command)

--- a/lib/openhab/core/items/player_item.rb
+++ b/lib/openhab/core/items/player_item.rb
@@ -39,24 +39,50 @@ module OpenHAB
         #   Send the {PLAY} command to the item
         #   @return [PlayerItem] `self`
 
+        # @!method play!
+        #   Send the {PLAY} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [PlayerItem] `self`
+
         # @!method pause
         #   Send the {PAUSE} command to the item
+        #   @return [PlayerItem] `self`
+
+        # @!method pause!
+        #   Send the {PAUSE} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [PlayerItem] `self`
 
         # @!method rewind
         #   Send the {REWIND} command to the item
         #   @return [PlayerItem] `self`
 
+        # @!method rewind
+        #   Send the {REWIND} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [PlayerItem] `self`
+
         # @!method fast_forward
         #   Send the {FASTFORWARD} command to the item
+        #   @return [PlayerItem] `self`
+
+        # @!method fast_forward!
+        #   Send the {FASTFORWARD} command to the item, even when
+        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [PlayerItem] `self`
 
         # @!method next
         #   Send the {NEXT} command to the item
         #   @return [PlayerItem] `self`
 
+        # @!method next!
+        #   Send the {NEXT} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [PlayerItem] `self`
+
         # @!method previous
         #   Send the {PREVIOUS} command to the item
+        #   @return [PlayerItem] `self`
+
+        # @!method previous!
+        #   Send the {PREVIOUS} command to the item, even when
+        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [PlayerItem] `self`
       end
     end

--- a/lib/openhab/core/items/rollershutter_item.rb
+++ b/lib/openhab/core/items/rollershutter_item.rb
@@ -41,16 +41,32 @@ module OpenHAB
         #   Send the {UP} command to the item
         #   @return [RollershutterItem] `self`
 
+        # @!method up!
+        #   Send the {UP} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [RollershutterItem] `self`
+
         # @!method down
         #   Send the {DOWN} command to the item
+        #   @return [RollershutterItem] `self`
+
+        # @!method down!
+        #   Send the {DOWN} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [RollershutterItem] `self`
 
         # @!method stop
         #   Send the {STOP} command to the item
         #   @return [RollershutterItem] `self`
 
+        # @!method stop!
+        #   Send the {STOP} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [RollershutterItem] `self`
+
         # @!method move
         #   Send the {MOVE} command to the item
+        #   @return [RollershutterItem] `self`
+
+        # @!method move!
+        #   Send the {MOVE} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [RollershutterItem] `self`
 
         # raw numbers translate directly to PercentType, not a DecimalType

--- a/lib/openhab/core/items/semantics/enumerable.rb
+++ b/lib/openhab/core/items/semantics/enumerable.rb
@@ -101,11 +101,30 @@ module Enumerable
     self if count { |i| i.command(command) }.positive?
   end
 
+  # Send a command to every item in the collection, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+  # @return [self]
+  def command!(command)
+    # We cannot alias this to #command above, otherwise it will call
+    # DSL::Items::Ensure::Item#command which checks for ensure_states
+    each { |i| i.command!(command) }
+    self
+  end
+
   # Update the state of every item in the collection
   # @return [self, nil] nil when `ensure` is in effect and all the items were already in the same state,
   #   otherwise self
   def update(state)
     self if count { |i| i.update(state) }.positive?
+  end
+
+  # Update the state of every item in the collection, even when
+  #   {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+  # @return [self]
+  def update!(state)
+    # We cannot alias this to #update above, otherwise it will call
+    # DSL::Items::Ensure::Item#update which checks for ensure_states
+    each { |i| i.update!(state) }
+    self
   end
 
   # @!method refresh

--- a/lib/openhab/core/items/switch_item.rb
+++ b/lib/openhab/core/items/switch_item.rb
@@ -67,8 +67,16 @@ module OpenHAB
         #   Send the {ON} command to the item
         #   @return [SwitchItem] `self`
 
+        # @!method on!
+        #   Send the {ON} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+        #   @return [SwitchItem] `self`
+
         # @!method off
         #   Send the {OFF} command to the item
+        #   @return [SwitchItem] `self`
+
+        # @!method off!
+        #   Send the {OFF} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [SwitchItem] `self`
       end
     end

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -24,7 +24,7 @@ module OpenHAB
 
         # Extensions for {::Item} to implement {Ensure}'s functionality
         #
-        # @see OpenHAB::DSL.ensure ensure
+        # @see OpenHAB::DSL::Items::Ensure::Ensurable#ensure ensure
         # @see OpenHAB::DSL.ensure_states ensure_states
         module Item
           include Ensurable


### PR DESCRIPTION
Implement the idea from https://community.openhab.org/t/jruby-openhab-rules-system/110598/379

```ruby
ensure_states!

# From now, all commands are "ensured", i.e. only sent when the current state is different
Item1.on
Item2.command(ON)

# While ensure_states! is active, we can still forcibly send a command regardless of the current state
Item2.on!
```
