### PR TITLE
upgrade checkout action from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -42,7 +42,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v2.0.0
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -87,7 +87,7 @@ jobs:
       matrix:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache openHAB setup
         id: cache
         uses: actions/cache@v3
@@ -135,7 +135,7 @@ jobs:
           - openhab_version: 4.1.0-SNAPSHOT
             jruby_version: jruby-9.3.10.0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.jruby_version }}
@@ -175,7 +175,7 @@ jobs:
       matrix:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}


### PR DESCRIPTION
To address deprecation warnings:
https://github.com/openhab/openhab-jruby/actions/runs/6643125723

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

