### PR TITLE
Infer accepted_item_type in ChannelBuilder

### DIFF
--- a/lib/openhab/core/things/profile_callback.rb
+++ b/lib/openhab/core/things/profile_callback.rb
@@ -14,9 +14,10 @@ module OpenHAB
         # @param [Command] command
         #
         def handle_command(command)
-          @dummy_channel_item ||= DSL::Items::ItemBuilder.item_factory.create_item(link.channel.accepted_item_type,
-                                                                                   "")
-          command = @dummy_channel_item.format_command(command)
+          unless instance_variable_defined?(:@dummy_channel_item)
+            @dummy_channel_item = DSL::Items::ItemBuilder.item_factory.create_item(link.channel.accepted_item_type, "")
+          end
+          command = @dummy_channel_item.format_command(command) if @dummy_channel_item
           super(command)
         end
 

--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -263,8 +263,14 @@ module OpenHAB
                     :default_tags,
                     :properties,
                     :description,
-                    :auto_update_policy,
-                    :accepted_item_type
+                    :auto_update_policy
+
+        class << self
+          # @!visibility private
+          def channel_type_registry
+            @channel_type_registry ||= OSGi.service("org.openhab.core.thing.type.ChannelTypeRegistry")
+          end
+        end
 
         #
         # Constructor for ChannelBuilder
@@ -284,7 +290,7 @@ module OpenHAB
         #   The default tags for this channel.
         # @param [:default, :recommend, :veto, org.openhab.core.thing.type.AutoUpdatePolicy] auto_update_policy
         #   The channel's auto update policy.
-        # @param [String] accepted_item_type The accepted item type.
+        # @param [String] accepted_item_type The accepted item type. If nil, infer the item type from the channel type.
         #
         def initialize(uid,
                        type,
@@ -341,6 +347,12 @@ module OpenHAB
                builder.with_accepted_item_type(accepted_item_type) if accepted_item_type
              end
              .build
+        end
+
+        # @!attribute [r] accepted_item_type
+        # @return [String] The accepted item type.
+        def accepted_item_type
+          @accepted_item_type ||= self.class.channel_type_registry.get_channel_type(type)&.item_type
         end
 
         private

--- a/spec/openhab/dsl/things/builder_spec.rb
+++ b/spec/openhab/dsl/things/builder_spec.rb
@@ -304,6 +304,16 @@ RSpec.describe OpenHAB::DSL::Things::Builder do
         expect(channel.properties).to eq("property1" => "testproperty")
         expect(channel.accepted_item_type).to eq "Number"
       end
+
+      it "infers accepted_item_type from ChannelTypeRegistry" do
+        thing = things.build do
+          thing "astro:sun:home" do
+            channel "test", "start"
+          end
+        end
+        channel = thing.channels["test"]
+        expect(channel.accepted_item_type).to eq "DateTime"
+      end
     end
   end
 end


### PR DESCRIPTION
The accepted_item_type should be inferred from the ChannelType when not specified, so that the created channel doesn't end up with a blank accepted_item_type.

This solves the problem mentioned in #186

There "may" still be cases where it cannot be inferred(?) so I've added back the check in profile callback's handle_command.