### PR TITLE
Avoid extra ensure state check from item helper commands

### DIFF
--- a/lib/openhab/core/items/dimmer_item.rb
+++ b/lib/openhab/core/items/dimmer_item.rb
@@ -102,7 +102,7 @@ module OpenHAB
         #
         def dim(amount = 1)
           target = [state&.-(amount), 0].compact.max
-          command(target)
+          command!(target)
           target
         end
 
@@ -121,7 +121,7 @@ module OpenHAB
         #
         def brighten(amount = 1)
           target = [state&.+(amount), 100].compact.min
-          command(target)
+          command!(target)
           target
         end
 
@@ -131,16 +131,6 @@ module OpenHAB
 
         # @!method decrease
         #   Send the {DECREASE} command to the item
-        #   @return [DimmerItem] `self`
-
-        # @!method increase!
-        #   Send the {INCREASE} command to the item, even when
-        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [DimmerItem] `self`
-
-        # @!method decrease!
-        #   Send the {DECREASE} command to the item, even when
-        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [DimmerItem] `self`
 
         # raw numbers translate directly to PercentType, not a DecimalType

--- a/lib/openhab/core/items/player_item.rb
+++ b/lib/openhab/core/items/player_item.rb
@@ -55,7 +55,7 @@ module OpenHAB
         #   Send the {REWIND} command to the item
         #   @return [PlayerItem] `self`
 
-        # @!method rewind
+        # @!method rewind!
         #   Send the {REWIND} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [PlayerItem] `self`
 
@@ -72,17 +72,8 @@ module OpenHAB
         #   Send the {NEXT} command to the item
         #   @return [PlayerItem] `self`
 
-        # @!method next!
-        #   Send the {NEXT} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [PlayerItem] `self`
-
         # @!method previous
         #   Send the {PREVIOUS} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method previous!
-        #   Send the {PREVIOUS} command to the item, even when
-        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [PlayerItem] `self`
       end
     end

--- a/lib/openhab/core/items/rollershutter_item.rb
+++ b/lib/openhab/core/items/rollershutter_item.rb
@@ -57,16 +57,8 @@ module OpenHAB
         #   Send the {STOP} command to the item
         #   @return [RollershutterItem] `self`
 
-        # @!method stop!
-        #   Send the {STOP} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [RollershutterItem] `self`
-
         # @!method move
         #   Send the {MOVE} command to the item
-        #   @return [RollershutterItem] `self`
-
-        # @!method move!
-        #   Send the {MOVE} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [RollershutterItem] `self`
 
         # raw numbers translate directly to PercentType, not a DecimalType

--- a/lib/openhab/core/items/switch_item.rb
+++ b/lib/openhab/core/items/switch_item.rb
@@ -50,9 +50,9 @@ module OpenHAB
         # @return [self]
         #
         def toggle
-          return on unless state?
+          return on! unless state?
 
-          command(!state)
+          command!(!state)
         end
 
         # @!method on?

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -36,6 +36,8 @@ module OpenHAB
           # sending the command
           %i[command update].each do |ensured_method|
             # def command(state)
+            #   # immediately send the command if it's a command, but not a state (like REFRESH)
+            #   return super(state) if state.is_a?(Command) && !state.is_a?(State)
             #   return super(state) unless Thread.current[:openhab_ensure_states]
             #
             #   formatted_state = format_command(state)
@@ -48,6 +50,8 @@ module OpenHAB
             # end
             class_eval <<~RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition
               def #{ensured_method}(state)
+                # immediately send the command if it's a command, but not a state (like REFRESH)
+                #{"return super(state) if state.is_a?(Command) && !state.is_a?(State)" if ensured_method == :command}
                 return super(state) unless Thread.current[:openhab_ensure_states]
 
                 formatted_state = format_#{ensured_method}(state)


### PR DESCRIPTION
 * toggle/dim/brighten just read the state; no need for them to run through ensure
 * refresh never needs to be ensured