### PR TITLE
Make ItemStateUpdatedEvent appear in yard

### DIFF
--- a/lib/openhab/core/events/item_state_updated_event.rb
+++ b/lib/openhab/core/events/item_state_updated_event.rb
@@ -5,17 +5,18 @@ require_relative "item_state_event"
 module OpenHAB
   module Core
     module Events
-      begin
+      # @deprecated OH3.4 if guard only needed in OH 3.4
+      if Gem::Version.new(OpenHAB::Core::VERSION) >= Gem::Version.new("4.0.0")
         java_import org.openhab.core.items.events.ItemStateUpdatedEvent
 
         #
         # {AbstractEvent} sent when an item's state has updated.
         #
+        # @since openHAB 4.0
+        #
         class ItemStateUpdatedEvent < ItemEvent
           include ItemState
         end
-      rescue NameError
-        # @deprecated OH3.4 OH3 will raise an error ItemStateUpdatedEvent is only in OH4
       end
     end
   end


### PR DESCRIPTION
Right now, it doesn't appear here: https://openhab.github.io/openhab-jruby/5.11/OpenHAB/Core/Events.html

