### PR TITLE
stop testing cucumber on openHAB 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,8 @@ jobs:
     strategy:
       matrix:
         openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
+        exclude:
+          - openhab_version: 3.4.5
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
bundler 3.5 was released today, which requires ruby >= 3.0 (jruby >= 9.4), which the 3.4 addon will fail trying to install. the 3.4 addon will not be receiving anymore updates, so just stop testing it