### PR TITLE
Support AND'd visibility and color rules in sitemap builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.4.5", "4.0.4", "4.1.0.M3", "4.1.0-SNAPSHOT"]
+        ["3.4.5", "4.0.4", "4.1.0.M4", "4.1.0-SNAPSHOT"]
       snapshot_date: |
         ${{ steps.snapshot-date.outputs.SNAPSHOT_DATE }}
     steps:
@@ -130,7 +130,7 @@ jobs:
         exclude:
           - openhab_version: 4.0.4
             jruby_version: jruby-9.3.10.0
-          - openhab_version: 4.1.0.M3
+          - openhab_version: 4.1.0.M4
             jruby_version: jruby-9.3.10.0
           - openhab_version: 4.1.0-SNAPSHOT
             jruby_version: jruby-9.3.10.0

--- a/lib/openhab/core/sitemaps/provider.rb
+++ b/lib/openhab/core/sitemaps/provider.rb
@@ -70,13 +70,17 @@ module OpenHAB
         #         text label: "Climate", icon: "if:mdi:home-thermometer-outline" do
         #           frame label: "Main Floor" do
         #             text item: MainFloor_AmbTemp
-        #             switch item: MainFloorThermostat_TargetMode, label: "Mode", mappings: %w[off auto cool heat]
+        #             # colors are set with a hash, with key being condition, and value being the color
+        #             switch item: MainFloorThermostat_TargetMode, label: "Mode", mappings: %w[off auto cool heat], label_color: { "==heat" => "red", "" => "black" }
+        #             # an array of conditions are OR'd together
+        #             switch item: MainFloorThermostat_TargetMode, label: "Mode", mappings: %w[off auto cool heat], label_color: { ["==heat", "==cool"], => "green" }
         #             setpoint item: MainFloorThermostat_SetPoint, label: "Set Point", visibility: "MainFloorThermostat_TargetMode!=off"
         #           end
         #           frame label: "Basement" do
         #             text item: Basement_AmbTemp
         #             switch item: BasementThermostat_TargetMode, label: "Mode", mappings: { OFF: "off", COOL: "cool", HEAT: "heat" }
-        #             setpoint item: BasementThermostat_SetPoint, label: "Set Point", visibility: "BasementThermostat_TargetMode!=off"
+        #             # nested arrays are conditions that are AND'd together, instead of OR'd (requires openHAB 4.1)
+        #             setpoint item: BasementThermostat_SetPoint, label: "Set Point", visibility: [["BasementThermostat_TargetMode!=off", "Vacation_Switch!=OFF"]]
         #           end
         #         end
         #       end


### PR DESCRIPTION
requires openHAB 4.1 to use AND, but fixes sitemaps to work in 4.1 at all