### PR TITLE
testing: load storage based type providers

### DIFF
--- a/lib/openhab/rspec/mocks/abstract_storage_based_type_provider_wrapped_storage_service.rb
+++ b/lib/openhab/rspec/mocks/abstract_storage_based_type_provider_wrapped_storage_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "delegate"
+
+module OpenHAB
+  module RSpec
+    # @!visibility private
+    module Mocks
+      class AbstractStorageBasedTypeProviderWrappedStorageService < SimpleDelegator
+        include org.openhab.core.storage.StorageService
+
+        def initialize(parent, ruby_klass, java_klass)
+          super(parent)
+          @ruby_klass = ruby_klass
+          @java_klass = java_klass
+        end
+
+        def getStorage(name, _class_loader) # rubocop:disable Naming/MethodName
+          super(name.sub(@ruby_klass.name, @java_klass.name), @java_klass.class_loader)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
create a dummy sub-class of AbstractStorageBasedTypeProvider. we don't need any more functionality than loading of types, but we do have to create the proper ones by finding existing instances

this helps things with dynamic thing types come online