### PR TITLE
spec: "autoupdate" channels from mock thing handler

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,7 +27,7 @@ source "https://rubygems.org"
 
 group(:test) do
   gem "rspec", "~> 3.11"
-  gem "openhab-scripting", "~> 0.1"
+  gem "openhab-scripting", "~> 5.0"
   gem "timecop"
 end
 
@@ -116,11 +116,6 @@ OpenHAB::Log.root.level = :debug
 OpenHAB::Log.events.level = :info
 ```
 
-- Sometimes items are set to `autoupdate="false"` in production to ensure the
-   devices responds, but you don't really care about the device in tests, you
-   just want to check if the effects of a rule happened. You can enable
-   autoupdating of all items by calling {OpenHAB::RSpec::Helpers#autoupdate_all_items}
-   from either your spec itself, or a `before` block.
 - Differing from when openHAB loads rules, all rules are loaded into a single
    JRuby execution context, so changes to globals in one file will affect other
    files. In particular, this applies to ids for reentrant timers will now share
@@ -137,6 +132,9 @@ OpenHAB::Log.events.level = :info
    addon like `binding-astro` if you need to be able to create things from your
    rules. Note that the addon isn't actually allowed to start, just be installed to
    make type metadata from XML available.
+- If you have any Things in your openHAB instance that take two minutes to come
+  online due to missing type metadata, you can force them to initialize
+  immediately by calling {OpenHAB::RSpec::Helpers#initialize_missing_thing_types}.
 
 ## Configuration
 
@@ -183,7 +181,6 @@ begin
   require "openhab/rspec"
 
   autorequires
-  set_up_autoupdates
   load_rules
   load_transforms
 rescue => e

--- a/lib/openhab/rspec/hooks.rb
+++ b/lib/openhab/rspec/hooks.rb
@@ -38,7 +38,6 @@ module OpenHAB
           end
 
           Helpers.autorequires unless Configuration.private_confdir
-          Helpers.send(:set_up_autoupdates)
           Helpers.load_transforms
           Helpers.load_rules
 
@@ -103,7 +102,6 @@ module OpenHAB
           # wipe this
           DSL::Items::TimedCommand.timed_commands.clear
           Timecop.return
-          restore_autoupdate_items
           Mocks::PersistenceService.instance.reset
           Hooks.cache_script_extension.sharedCache.clear if DSL.shared_cache
           DSL.persistence!(nil)

--- a/lib/openhab/rspec/mocks/thing_handler.rb
+++ b/lib/openhab/rspec/mocks/thing_handler.rb
@@ -29,7 +29,13 @@ module OpenHAB
           @thing = thing
         end
 
-        def handle_command(channel, command); end
+        def handle_command(channel_uid, command)
+          channel = thing.get_channel(channel_uid)
+          return unless channel
+          return if channel.auto_update_policy == org.openhab.core.thing.type.AutoUpdatePolicy::VETO
+
+          callback&.state_updated(channel_uid, command) if command.is_a?(Core::Types::State)
+        end
 
         def set_callback(callback)
           @callback = callback

--- a/spec/openhab/dsl/items/timed_command_spec.rb
+++ b/spec/openhab/dsl/items/timed_command_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe OpenHAB::DSL::Items::TimedCommand do
     manualitem.update(OFF)
     manualitem.command(ON, for: 3.seconds)
     manualitem.update(ON)
-    autoupdate_all_items
+    manualitem.metadata[:autoupdate] = true
     time_travel_and_execute_timers(5.seconds)
     expect(manualitem.state).to eq OFF
   end

--- a/spec/openhab/rspec/helpers_spec.rb
+++ b/spec/openhab/rspec/helpers_spec.rb
@@ -18,18 +18,5 @@ RSpec.describe OpenHAB::RSpec::Helpers do
       subject.load_rules
     end
   end
-
-  describe "autoupdate_all_items" do
-    it "works" do
-      items.build { switch_item "Switch1", autoupdate: false }
-
-      Switch1.on
-      expect(Switch1).to be_null
-
-      autoupdate_all_items
-      Switch1.on
-      expect(Switch1).to be_on
-    end
-  end
 end
 # rubocop:enable RSpec/NamedSubject


### PR DESCRIPTION
this obviates the need for autoupdate_all, so deprecate that, making it a no-op, and remove associated helpers