### PR TITLE
Support selecting multiple types of location and equipment

### DIFF
--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -607,22 +607,31 @@ module Enumerable
   # @!group Filtering Methods
   #
 
-  # Returns a new array of items that are a semantics Location (optionally of the given type)
+  #
+  # Returns a new array of items that are a semantics Location (optionally of one of the given types)
   # @return [Array<Item>]
-  def locations(type = nil)
+  #
+  # @example Get all rooms
+  #   items.locations(Semantics::Room)
+  #
+  # @example Get all bedrooms and bathrooms
+  #   items.locations(Semantics::Bedroom, Semantics::Bathroom)
+  #
+  def locations(*types)
     begin
-      raise ArgumentError if type && !(type < Semantics::Location)
+      raise ArgumentError unless types.all? { |type| type < Semantics::Location }
     rescue ArgumentError, TypeError
       raise ArgumentError, "type must be a subclass of Location"
     end
 
     result = select(&:location?)
-    result.select! { |i| i.location_type <= type } if type
+    result.select! { |i| types.any? { |type| i.location_type <= type } } unless types.empty?
 
     result
   end
 
-  # Returns a new array of items that are a semantics equipment (optionally of the given type)
+  #
+  # Returns a new array of items that are a semantics equipment (optionally of one of the given types)
   #
   # @note As {Semantics::Equipment equipments} are usually
   #   {GroupItem GroupItems}, this method therefore returns an array of
@@ -633,16 +642,20 @@ module Enumerable
   # @return [Array<Item>]
   #
   # @example Get all TVs in a room
-  #   lGreatRoom.equipments(Semantics::Screen)
-  def equipments(type = nil)
+  #   lGreatRoom.equipments(Semantics::Television)
+  #
+  # @example Get all TVs and Speakers in a room
+  #   lGreatRoom.equipments(Semantics::Television, Semantics::Speaker)
+  #
+  def equipments(*types)
     begin
-      raise ArgumentError if type && !(type < Semantics::Equipment)
+      raise ArgumentError unless types.all? { |type| type < Semantics::Equipment }
     rescue ArgumentError, TypeError
       raise ArgumentError, "type must be a subclass of Equipment"
     end
 
     result = select(&:equipment?)
-    result.select! { |i| i.equipment_type <= type } if type
+    result.select! { |i| types.any? { |type| i.equipment_type <= type } } unless types.empty?
 
     result
   end

--- a/spec/openhab/core/items/semantics_spec.rb
+++ b/spec/openhab/core/items/semantics_spec.rb
@@ -205,12 +205,38 @@ RSpec.describe OpenHAB::Core::Items::Semantics do
       end
     end
 
+    describe "#locations" do
+      it "supports multiple arguments" do
+        items.build do
+          group_item "gIndoor", tag: Semantics::Indoor do
+            group_item "gLivingRoom", tag: Semantics::LivingRoom
+            group_item "gKitchen", tag: Semantics::Kitchen
+            group_item "gBedroom", tag: Semantics::Bedroom
+          end
+        end
+
+        expect(gIndoor.locations(Semantics::LivingRoom, Semantics::Kitchen)).to match_array([gLivingRoom, gKitchen])
+      end
+    end
+
     describe "#equipments" do
       it "gets sub-equipment" do
         items.build do
           group_item "SubEquipment", group: Patio_Light_Bulb, tag: Semantics::Lightbulb
         end
         expect(gPatio.equipments(Semantics::Lightbulb).members.equipments).to eql [SubEquipment]
+      end
+
+      it "supports multiple arguments" do
+        items.build do
+          group_item "gIndoor", tag: Semantics::Indoor do
+            group_item "gTV", tag: Semantics::Television
+            group_item "gSpeaker", tag: Semantics::Speaker
+            group_item "gLightbulb", tag: Semantics::Lightbulb
+          end
+        end
+
+        expect(gIndoor.equipments(Semantics::Television, Semantics::Speaker)).to match_array([gTV, gSpeaker])
       end
     end
 


### PR DESCRIPTION
Make it possible to select multiple types of equipment and location, e.g.

```ruby
gLivingRoom.equipments(Semantics::Television, Semantics::Speaker, Semantics::Lightbulb)
items.locations(Semantics::Bedroom, Semantics::Bathroom)
```