### PR TITLE
Add support for TimeSeries

### DIFF
--- a/lib/openhab/core/events/item_time_series_updated_event.rb
+++ b/lib/openhab/core/events/item_time_series_updated_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# @deprecated OH4.0 guard not needed in OH 4.1
+return unless OpenHAB::Core.version >= OpenHAB::Core::V4_1
+
+module OpenHAB
+  module Core
+    module Events
+      java_import org.openhab.core.items.events.ItemTimeSeriesUpdatedEvent
+
+      #
+      # {AbstractEvent} sent when an item received a time series update.
+      #
+      # @!attribute [r] time_series
+      #   @return [TimeSeries] The updated time series.
+      #
+      # @since openHAB 4.1
+      # @see DSL::Rules::BuilderDSL#time_series_updated #time_series_updated rule trigger
+      #
+      class ItemTimeSeriesUpdatedEvent < ItemEvent; end
+    end
+  end
+end

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -208,6 +208,18 @@ module OpenHAB
         end
 
         #
+        # @method time_series=(time_series)
+        #   Set a new time series.
+        #
+        #   This will trigger a {DSL::Rules::BuilderDSL#time_series_updated time_series_updated} event.
+        #
+        #   @param [Core::Types::TimeSeries] time_series New time series to set.
+        #   @return [void]
+        #
+        #   @since openHAB 4.1
+        #
+
+        #
         # Defers notifying openHAB of modifications to multiple attributes until the block is complete.
         #
         # @param [true, false] force When true, allow modifications to file-based items.

--- a/lib/openhab/core/profile_factory.rb
+++ b/lib/openhab/core/profile_factory.rb
@@ -15,7 +15,12 @@ module OpenHAB
       include Singleton
 
       class Profile
-        include org.openhab.core.thing.profiles.StateProfile
+        # @deprecated OH 4.0 only include TimeSeriesProfile in OH 4.1, because it extends StateProfile
+        if OpenHAB::Core.version >= OpenHAB::Core::V4_1
+          include org.openhab.core.thing.profiles.TimeSeriesProfile
+        else
+          include org.openhab.core.thing.profiles.StateProfile
+        end
 
         def initialize(callback, context, uid, thread_locals, block)
           unless callback.class.ancestors.include?(Things::ProfileCallback)
@@ -64,6 +69,14 @@ module OpenHAB
           process_event(:state_from_item, state: state)
         end
 
+        # @deprecated OH 4.0 guard is only needed for < OH 4.1
+        if OpenHAB::Core.version >= OpenHAB::Core::V4_1
+          # @!visibility private
+          def onTimeSeriesFromHandler(time_series)
+            process_event(:time_series_from_handler, time_series: time_series)
+          end
+        end
+
         private
 
         def process_event(event, **params)
@@ -77,6 +90,8 @@ module OpenHAB
           params[:channel_uid] = @callback.link.linked_uid
           params[:state] ||= nil
           params[:command] ||= nil
+          # @deprecated OH 4.0 guard is only needed for < OH 4.1
+          params[:time_series] ||= nil if OpenHAB::Core.version >= OpenHAB::Core::V4_1
 
           kwargs = {}
           @block.parameters.each do |(param_type, name)|

--- a/lib/openhab/core/things/profile_callback.rb
+++ b/lib/openhab/core/things/profile_callback.rb
@@ -40,6 +40,11 @@ module OpenHAB
           state = link.item.format_update(state)
           super(state)
         end
+
+        # @!method send_time_series(time_series)
+        #   Send a time series to the framework.
+        #   @param [TimeSeries] time_series
+        #   @since openHAB 4.1
       end
     end
   end

--- a/lib/openhab/core/types/time_series.rb
+++ b/lib/openhab/core/types/time_series.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# @deprecated OH4.0 this guard is not needed on OH4.1
+return unless OpenHAB::Core.version >= OpenHAB::Core::V4_1
+
+require "forwardable"
+
+module OpenHAB
+  module Core
+    module Types
+      TimeSeries = org.openhab.core.types.TimeSeries
+
+      #
+      # {TimeSeries} is used to transport a set of states together with their timestamp.
+      #
+      # The states are sorted chronologically. The entries can be accessed like an array.
+      #
+      # @since openHAB 4.1
+      #
+      # @example
+      #   time_series = TimeSeries.new # defaults to :add policy
+      #                           .add(Time.at(2), DecimalType.new(2))
+      #                           .add(Time.at(1), DecimalType.new(1))
+      #                           .add(Time.at(3), DecimalType.new(3))
+      #   logger.info "first entry: #{time_series.first.state}" # => 1
+      #   logger.info "last entry: #{time_series.last.state}" # => 3
+      #   logger.info "second entry: #{time_series[1].state}" # => 2
+      #   logger.info "sum: #{time_series.sum(&:state)}" # => 6
+      #
+      # @see DSL::Rules::BuilderDSL#time_series_updated #time_series_updated rule trigger
+      #
+      class TimeSeries
+        extend Forwardable
+
+        # @!attribute [r] policy
+        #   Returns the persistence policy of this series.
+        #   @see org.openhab.core.types.TimeSeries#getPolicy()
+        #   @return [org.openhab.core.types.TimeSeries.Policy]
+
+        # @!attribute [r] begin
+        #   Returns the timestamp of the first element in this series.
+        #   @return [Instant]
+
+        # @!attribute [r] end
+        #   Returns the timestamp of the last element in this series.
+        #   @return [Instant]
+
+        # @!attribute [r] size
+        #   Returns the number of elements in this series.
+        #   @return [Integer]
+
+        #
+        # Create a new instance of TimeSeries
+        #
+        # @param [:add, :replace, org.openhab.core.types.TimeSeries.Policy] policy
+        #   The persistence policy of this series.
+        #
+        def initialize(policy = :replace)
+          policy = Policy.value_of(policy.to_s.upcase) if policy.is_a?(Symbol)
+          super
+        end
+
+        # Returns true if the series' policy is `ADD`.
+        # @return [true,false]
+        def add?
+          policy == Policy::ADD
+        end
+
+        # Returns true if the series' policy is `REPLACE`.
+        # @return [true,false]
+        def replace?
+          policy == Policy::REPLACE
+        end
+
+        # @!visibility private
+        def inspect
+          "#<OpenHAB::Core::Types::TimeSeries " \
+            "policy=#{policy} " \
+            "begin=#{self.begin} " \
+            "end=#{self.end} " \
+            "size=#{size}>"
+        end
+
+        #
+        # Returns the content of this series.
+        # @return [Array<org.openhab.core.types.TimeSeries.Entry>]
+        #
+        def states
+          get_states.to_array.to_a.freeze
+        end
+
+        # rename raw methods so we can overwrite them
+        # @!visibility private
+        alias_method :add_instant, :add
+
+        #
+        # Adds a new element to this series.
+        #
+        # Elements can be added in an arbitrary order and are sorted chronologically.
+        #
+        # @note This method returns self so it can be chained, unlike the Java version.
+        #
+        # @param [Instant, #to_zoned_date_time, #to_instant] instant An instant for the given state.
+        # @param [State] state The State at the given timestamp.
+        # @return [self]
+        #
+        def add(instant, state)
+          instant = instant.to_zoned_date_time if instant.respond_to?(:to_zoned_date_time)
+          instant = instant.to_instant if instant.respond_to?(:to_instant)
+          add_instant(instant, state)
+          self
+        end
+
+        # any method that exists on Array gets forwarded to states
+        delegate (Array.instance_methods - instance_methods) => :states
+      end
+    end
+  end
+end
+
+TimeSeries = OpenHAB::Core::Types::TimeSeries unless Object.const_defined?(:TimeSeries)

--- a/lib/openhab/core_ext/java/instant.rb
+++ b/lib/openhab/core_ext/java/instant.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module CoreExt
+    module Java
+      java_import java.time.Instant
+
+      # Extensions to {java.time.Instant}
+      class Instant < java.lang.Object; end
+    end
+  end
+end
+
+Instant = OpenHAB::CoreExt::Java::Instant unless Object.const_defined?(:Instant)

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -84,14 +84,17 @@ module OpenHAB
     # @param [String, nil] label The label for the profile. When nil, the profile will not be visible in the UI.
     # @param [org.openhab.core.config.core.ConfigDescription, nil] config_description
     #   The configuration description for the profile so that it can be configured in the UI.
-    # @yield [event, command: nil, state: nil, callback:, link:, item:, channel_uid:, configuration:, context:]
+    # @yield [event, command: nil, state: nil, time_series: nil, callback:, link:, item:, channel_uid:, configuration:, context:]
     #   All keyword params are optional. Any that aren't defined won't be passed.
-    # @yieldparam [:command_from_item, :state_from_item, :command_from_handler, :state_from_handler] event
+    # @yieldparam [:command_from_item, :state_from_item, :command_from_handler, :state_from_handler, :time_series_from_handler] event
     #   The event that needs to be processed.
     # @yieldparam [Command, nil] command
     #   The command being sent for `:command_from_item` and `:command_from_handler` events.
     # @yieldparam [State, nil] state
     #   The state being sent for `:state_from_item` and `:state_from_handler` events.
+    # @yieldparam [TimeSeries] time_series
+    #   The time series for `:time_series_from_handler` events.
+    #   Only available since openHAB 4.1.
     # @yieldparam [Core::Things::ProfileCallback] callback
     #   The callback to be used to customize the action taken.
     # @yieldparam [Core::Things::ItemChannelLink] link
@@ -105,6 +108,7 @@ module OpenHAB
     #
     # @see org.openhab.core.thing.profiles.Profile
     # @see org.openhab.core.thing.profiles.StateProfile
+    # @see org.openhab.core.thing.profiles.TimeSeriesProfile
     #
     # @example Vetoing a command
     #   profile(:veto_closing_shades) do |event, item:, command:|

--- a/lib/openhab/dsl/rules/name_inference.rb
+++ b/lib/openhab/dsl/rules/name_inference.rb
@@ -64,6 +64,8 @@ module OpenHAB
               infer_rule_name_from_item_registry_trigger(trigger)
             when :thing_added, :thing_removed, :thing_updated
               infer_rule_name_from_thing_trigger(trigger)
+            when :time_series_updated
+              infer_rule_name_from_time_series_trigger(items)
             when :on_start
               infer_rule_name_from_on_start_trigger(items)
             end
@@ -134,6 +136,11 @@ module OpenHAB
               thing_updated: "Thing updated",
               thing_removed: "Thing removed"
             }[trigger]
+          end
+
+          # formulate a readable rule name from a time series updated trigger
+          def infer_rule_name_from_time_series_trigger(items)
+            "#{format_array(items.map(&:name))} time series updated"
           end
 
           # formulate a readable rule name from an on_start trigger

--- a/lib/openhab/rspec/mocks/thing_handler.rb
+++ b/lib/openhab/rspec/mocks/thing_handler.rb
@@ -37,6 +37,10 @@ module OpenHAB
           callback&.state_updated(channel_uid, command) if command.is_a?(Core::Types::State)
         end
 
+        def send_time_series(channel_uid, time_series)
+          @callback&.send_time_series(channel_uid, time_series)
+        end
+
         def set_callback(callback)
           @callback = callback
         end

--- a/spec/openhab/core/types/time_series_spec.rb
+++ b/spec/openhab/core/types/time_series_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# @deprecated OH 4.0 guard not needed in OH 4.1
+return unless OpenHAB::Core.version >= OpenHAB::Core::V4_1
+
+RSpec.describe OpenHAB::Core::Types::TimeSeries do
+  let(:ts) do
+    described_class.new(:add).tap do |ts|
+      ts.add(Instant.of_epoch_second(1), DecimalType.new(1))
+      ts.add(Instant.of_epoch_second(2), DecimalType.new(2))
+    end
+  end
+
+  it "is inspectable" do
+    expect(described_class.new(:add).inspect).to eql "#<OpenHAB::Core::Types::TimeSeries policy=ADD " \
+                                                     "begin=+1000000000-12-31T23:59:59.999999999Z " \
+                                                     "end=-1000000000-01-01T00:00:00Z size=0>"
+  end
+
+  it "is accessible without using a fully qualified name" do
+    TimeSeries.new
+  end
+
+  it "supports specifying the policy as a symbol" do
+    expect(TimeSeries.new(:add).policy).to be TimeSeries::Policy::ADD
+    expect(TimeSeries.new(:add)).to be_add
+    expect(TimeSeries.new(:replace).policy).to be TimeSeries::Policy::REPLACE
+    expect(TimeSeries.new(:replace)).to be_replace
+  end
+
+  it "defaults to replace policy" do
+    expect(TimeSeries.new).to be_replace
+  end
+
+  describe "#add?" do
+    it "works" do
+      expect(ts.add?).to be true
+    end
+  end
+
+  describe "#replace?" do
+    it "works" do
+      expect(ts.replace?).to be false
+    end
+  end
+
+  describe "#add" do
+    it "accepts a Ruby time as instant" do
+      ts.add(Time.at(0), DecimalType.new(1))
+      expect(ts.begin).to eql Instant.of_epoch_second(0)
+    end
+  end
+
+  context "when accessed as an Array" do
+    it "is frozen" do
+      expect(ts.states).to be_frozen
+      expect { ts.unshift }.to raise_error FrozenError
+    end
+
+    it "supports #to_a" do
+      expect(ts.to_a).to all(be_a TimeSeries::Entry)
+    end
+
+    it "supports #[]" do
+      expect(ts[0].timestamp).to eql Instant.of_epoch_second(1)
+      expect(ts[0].state).to eql DecimalType.new(1)
+    end
+
+    it "supports #first" do
+      expect(ts.first.timestamp).to eql Instant.of_epoch_second(1)
+      expect(ts.first.state).to eql DecimalType.new(1)
+    end
+
+    it "supports #last" do
+      expect(ts.last.timestamp).to eql Instant.of_epoch_second(2)
+      expect(ts.last.state).to eql DecimalType.new(2)
+    end
+
+    it "can be mapped to its states" do
+      expect(ts.map(&:state)).to eql [DecimalType.new(1), DecimalType.new(2)]
+      expect(ts.sum(&:state)).to eql DecimalType.new(3)
+    end
+
+    it "supports #each" do
+      sum = DecimalType.new(0)
+      ts.each { |entry| sum += entry.state }
+      expect(sum).to eql DecimalType.new(3)
+    end
+  end
+end


### PR DESCRIPTION
- [x] add `TimeSeries` class and make it array-like
- [x] add `java.time.Instant` to the Object scope
- [x] document: `GenericItem#time_series=` 
- [x] rule trigger: `time_series_updated`
- [x] add: `ItemTimeSeriesUpdatedEvent` to document `event.time_series`
- [x] document profile callback method `send_time_series`
- [x] add `:time_series_from_handler` profile event
- [x] TimeSeries.new defaults to `:replace`
