### PR TITLE
Refactor item lookup to speed up item builder

### DIFF
--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -74,7 +74,7 @@ module OpenHAB
       ruby2_keywords def method_missing(method, *args)
         return super unless args.empty? && !block_given?
 
-        logger.trace("method missing, performing openHAB Lookup for: #{method}")
+        logger.trace { "method missing, performing openHAB Lookup for: #{method}" }
         EntityLookup.lookup_entity(method,
                                    create_dummy_items: self.class.respond_to?(:create_dummy_items?) &&
                                      self.class.create_dummy_items?) || super
@@ -82,7 +82,7 @@ module OpenHAB
 
       # @!visibility private
       def respond_to_missing?(method, *)
-        logger.trace("Checking if openHAB entities exist for #{method}")
+        logger.trace { "Checking if openHAB entities exist for #{method}" }
         EntityLookup.lookup_entity(method) || super
       end
 
@@ -121,14 +121,14 @@ module OpenHAB
         # @return [Things::Thing, nil]
         #
         def lookup_thing(uid)
-          logger.trace("Looking up thing '#{uid}'")
+          logger.trace { "Looking up thing '#{uid}'" }
           uid = uid.to_s if uid.is_a?(Symbol)
 
           uid = Things::ThingUID.new(uid) unless uid.is_a?(Things::ThingUID)
           thing = $things.get(uid)
           return unless thing
 
-          logger.trace("Retrieved Thing(#{thing}) from registry for uid: #{uid}")
+          logger.trace { "Retrieved Thing(#{thing}) from registry for uid: #{uid}" }
           Things::Proxy.new(thing)
         end
 
@@ -164,7 +164,7 @@ module OpenHAB
         # @return [Item, nil]
         #
         def lookup_item(name)
-          logger.trace("Looking up item '#{name}'")
+          logger.trace { "Looking up item '#{name}'" }
           name = name.to_s if name.is_a?(Symbol)
           item = $ir.get(name)
           Items::Proxy.new(item) unless item.nil?

--- a/lib/openhab/core/items/registry.rb
+++ b/lib/openhab/core/items/registry.rb
@@ -21,15 +21,13 @@ module OpenHAB
         # @return [Item] Item from registry, nil if item missing or requested item is a Group Type
         def [](name)
           EntityLookup.lookup_item(name)
-        rescue org.openhab.core.items.ItemNotFoundException
-          nil
         end
 
         # Returns true if the given item name exists
         # @param name [String] Item name to check
         # @return [true,false] true if the item exists, false otherwise
         def key?(name)
-          !$ir.getItems(name).empty?
+          !$ir.get(name).nil?
         end
         alias_method :include?, :key?
         # @deprecated


### PR DESCRIPTION
No need to get all items just to check the existence of one. It got slower and slower as the number of items increase.
This change sped up the lookup considerably. I discovered this problem when trying to create 100,000 items (as a test).

In my production code, the time taken to create 100 things and 900 items went down from 16s to 6.6s