### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Cache openHAB setup
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tmp/
           key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
@@ -100,7 +100,7 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
@@ -111,7 +111,7 @@ jobs:
           OPENHAB_VERSION: ${{ matrix.openhab_version }}
         run: bin/rake openhab:setup
       - name: Upload openHAB Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.cache.outputs.cache-hit != 'true' && failure()
         with:
           name: openHAB-setup-logs-${{ matrix.openhab_version }}
@@ -141,13 +141,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.jruby_version }}
           bundler-cache: true
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
           java-package: jre
       - name: Restore openHAB setup
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tmp/
           key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
@@ -155,14 +155,14 @@ jobs:
         run: bin/rspec --format progress --format html --out rspec.html
         timeout-minutes: 6
       - name: Upload openHAB Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: RSpec-logs-${{ matrix.openhab_version }}-${{ matrix.jruby_version }}
           path: tmp/openhab/userdata/logs
           retention-days: 2
       - name: Upload RSpec results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: RSpec-results-openHAB-${{ matrix.openhab_version }}-jruby-${{ matrix.jruby_version }}
@@ -184,13 +184,13 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
           rubygems: 3.4.22
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
           java-package: jre
       - name: Restore openHAB setup
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: tmp/
           key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
@@ -198,7 +198,7 @@ jobs:
         run: bin/rake features
         timeout-minutes: 4
       - name: Upload openHAB Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: Cucumber-logs-openHAB-${{ matrix.openhab_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       new_version: ${{ steps.bump_version.outputs.new_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: git-actions/set-user@v1
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref_name || github.ref_name }}
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Github is issuing warnings about nodejs update from v16 to v20.
https://github.com/openhab/openhab-jruby/actions/runs/7655572981

