### PR TITLE
Support `changed Item, from: { X => Y }`

### DIFF
--- a/lib/openhab/dsl/rules/triggers/changed.rb
+++ b/lib/openhab/dsl/rules/triggers/changed.rb
@@ -19,16 +19,18 @@ module OpenHAB
           # @param [Core::Items::Item, Core::Items::GroupItem::Members] item item to create trigger for
           # @param [Core::Types::State, Symbol, #===, nil] from state to restrict trigger to
           # @param [Core::Types::State, Symbol, #===, nil] to state to restrict trigger to
-          # @param [Duration, nil] duration duration to delay trigger until to state is met
+          # @param [Duration, Proc, nil] duration duration to delay trigger until to state is met
           # @param [Object] attach object to be attached to the trigger
           #
           # @return [org.openhab.core.automation.Trigger] openHAB triggers
           #
           def trigger(item:, from:, to:, duration:, attach:)
             if duration
-              item_name = item.respond_to?(:name) ? item.name : item.to_s
-              logger.trace("Creating Changed Wait Change Trigger for Item(#{item_name}) Duration(#{duration}) " \
-                           "To(#{to}) From(#{from}) Attach(#{attach})")
+              if logger.trace?
+                item_name = item.respond_to?(:name) ? item.name : item.to_s
+                logger.trace("Creating Changed Wait Change Trigger for Item(#{item_name}) Duration(#{duration}) " \
+                             "To(#{to}) From(#{from}) Attach(#{attach})")
+              end
               conditions = Conditions::Duration.new(to: to, from: from, duration: duration)
               changed_trigger(item: item, from: nil, to: nil, attach: attach, conditions: conditions)
             else

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -241,6 +241,13 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
         test_changed_trigger("Switch1", initial_state: OFF, new_state: ON)
         test_changed_trigger("Switch1", initial_state: ON, new_state: ON, expect_triggered: nil)
         test_changed_trigger("Switch1", initial_state: ON, new_state: OFF)
+        test_changed_trigger("Switch1", initial_state: OFF, new_state: ON, from: { OFF => ON })
+        test_changed_trigger("Switch1", initial_state: OFF, new_state: ON, from: { OFF => ON, ON => OFF })
+        test_changed_trigger("Switch1",
+                             initial_state: NULL,
+                             new_state: ON,
+                             from: { OFF => ON, ON => OFF },
+                             expect_triggered: nil)
         test_changed_trigger("Alarm_Mode1, Alarm_Mode2",
                              new_state: 3,
                              expect_triggered: "Alarm_Mode1")


### PR DESCRIPTION
This way it's possible to specify specific from/to combinations and not just every permutation of it

e.g.
```ruby
changed X, from: { 1 => 2, 4 => 5 } 
# vs
changed X, from: [1, 4], to: [2, 5] # this would trigger on 1 => 5 and 4 => 2
```