### PR TITLE
Infer id for rules created from UI

### DIFF
--- a/lib/openhab/dsl/rules/name_inference.rb
+++ b/lib/openhab/dsl/rules/name_inference.rb
@@ -27,6 +27,7 @@ module OpenHAB
           # get the block's source location, and simplify to a simple filename
           def infer_rule_id_from_block(block)
             file = File.basename(block.source_location.first)
+            file = "script:#{$ctx["ruleUID"]}" if $ctx&.key?("ruleUID") && file == "<script>"
             "#{file}:#{block.source_location.last}"
           end
 


### PR DESCRIPTION
So that if someone created a rule from a UI script, it shows the creator's uid + line number within that ui rule