### PR TITLE
Use lowercase in watch trigger label to be consistent with core

### DIFF
--- a/lib/openhab/dsl/rules/triggers/watch/watch_handler.rb
+++ b/lib/openhab/dsl/rules/triggers/watch/watch_handler.rb
@@ -301,7 +301,7 @@ module OpenHAB
               Core.automation_manager.add_trigger_type(org.openhab.core.automation.type.TriggerType.new(
                                                          WATCH_TRIGGER_MODULE_ID,
                                                          nil,
-                                                         "A path change event is detected",
+                                                         "a path change event is detected",
                                                          "Triggers when a path change event is detected",
                                                          nil,
                                                          org.openhab.core.automation.Visibility::VISIBLE,


### PR DESCRIPTION
Currently it looks like this:
<img width="442" alt="image" src="https://github.com/openhab/openhab-jruby/assets/2554958/e58eddf9-a749-4c5b-ae4a-56b6f634f8d2">

This should be lowercased. 