### PR TITLE
Tweak Rule ID inference to work with F7 router

### DIFF
--- a/lib/openhab/dsl/rules/name_inference.rb
+++ b/lib/openhab/dsl/rules/name_inference.rb
@@ -26,9 +26,9 @@ module OpenHAB
         class << self
           # get the block's source location, and simplify to a simple filename
           def infer_rule_id_from_block(block)
-            file = File.basename(block.source_location.first)
+            file = File.basename(block.source_location.first, ".rb")
             file = "script:#{$ctx["ruleUID"]}" if $ctx&.key?("ruleUID") && file == "<script>"
-            "#{file}:#{block.source_location.last}"
+            "#{file}:#{block.source_location.last}".tr(".", "_")
           end
 
           # formulate a readable rule name such as "TestSwitch received command ON" if possible

--- a/spec/openhab/log_spec.rb
+++ b/spec/openhab/log_spec.rb
@@ -57,16 +57,18 @@ RSpec.describe OpenHAB::Log do
 
     it "uses the rule id inside a timer block inside a rule" do
       executed = false
+      logger_name = nil
       rule "log test" do
         on_load
         run do
           after(1.second) do
             executed = true
-            expect(logger.name).to match(/^org\.openhab\.automation\.jrubyscripting\.rule\.log_spec\.rb:(?:\d+)$/)
+            logger_name = logger.name
           end
         end
       end
       time_travel_and_execute_timers(5.seconds)
+      expect(logger_name).to match(/^org\.openhab\.automation\.jrubyscripting\.rule\.log_spec:(?:\d+)$/)
       expect(executed).to be true
     end
 


### PR DESCRIPTION
Framework7 doesn't like dots in the dynamic route path.
Accessing the script using the url /settings/scripts/filename.rb:xx will result in a 404 because no route would match.