### PR TITLE
Sitemaps: support Button widgets inside buttongrids

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ FactoryBot:
 Layout/LineLength:
   AllowedPatterns:
     - "# @!method" # Some YARD tags can't be broken up onto multiple lines
+    - "# @overload"
     - "# @example"
     - "# @see"
     - "data:[a-z/]+;base64," # Base64 data is long

--- a/spec/openhab/dsl/sitemaps/builder_spec.rb
+++ b/spec/openhab/dsl/sitemaps/builder_spec.rb
@@ -625,6 +625,43 @@ RSpec.describe OpenHAB::DSL::Sitemaps::Builder do
         end
       end.to raise_error(ArgumentError)
     end
+
+    # @deprecated OH 4.1 guard is only needed for < OH 4.2
+    describe "with button sub-widgets", if: OpenHAB::Core.version >= OpenHAB::Core::V4_2 do
+      it "works" do
+        s = sitemaps.build do
+          sitemap "default" do
+            buttongrid do
+              button row: 1, column: 1, click: "BACK", label: "Back", icon: "f7:return"
+              button row: 1, column: 2, click: "HOME", label: "Menu", icon: "material:apps"
+            end
+          end
+        end
+
+        bg = s.children.first
+        buttons = bg.children
+        expect(buttons.size).to eq 2
+        expect(buttons[0].row).to eq 1
+        expect(buttons[1].cmd).to eq "HOME"
+      end
+
+      { row: 1, column: 1, click: "CMD" }.tap do |arguments|
+        arguments.each_key do |arg|
+          it "raises an error when '#{arg}' argument is missing" do
+            expect do
+              sitemaps.build do
+                sitemap "default" do
+                  buttongrid do
+                    arguments_with_missing_key = arguments.reject { |k, _| k == arg }
+                    button(**arguments_with_missing_key)
+                  end
+                end
+              end
+            end.to raise_error(ArgumentError)
+          end
+        end
+      end
+    end
   end
 
   it "can add a default" do


### PR DESCRIPTION
Buttongrid can now contain `Button` widgets which allows each button to be linked to individual item, plus each being set to different color / visibility

https://github.com/openhab/openhab-core/pull/4223

Currently, the "old" `button` option for buttongrid is still supported too, so it's backwards compatible with oh4.1

Adding buttons to a buttongrid with positional arguments
```ruby
sitemaps.build do
  sitemap "remote" do
    buttongrid item: RCButton do
      button 1, 1, "BACK", "Back", "f7:return"
      button 1, 2, "HOME", "Menu", "material:apps"
      button 1, 3, "YELLOW", "Search", "f7:search"
      button 2, 2, "UP", "Up", "f7:arrowtriangle_up"
      button 4, 2, "DOWN", "Down", "f7:arrowtriangle_down"
      button 3, 1, "LEFT", "Left", "f7:arrowtriangle_left"
      button 3, 3, "RIGHT", "Right", "f7:arrowtriangle_right"
      button 3, 2, "ENTER", "Enter", "material:adjust"
    end
  end
end
```


Adding buttons to a buttongrid with keyword arguments
```ruby
sitemaps.build do
  sitemap "remote" do
    buttongrid item: RCButton do
      # These buttons will use the default item assigned to the buttongrid (RCButton)
      button row: 1, column: 1, click: "BACK", icon: "f7:return"
      button row: 1, column: 2, click: "HOME", icon: "material:apps"
      button row: 1, column: 3, click: "YELLOW", icon: "f7:search"
      button row: 2, column: 2, click: "UP", icon: "f7:arrowtriangle_up"
      button row: 4, column: 2, click: "DOWN", icon: "f7:arrowtriangle_down"
      button row: 3, column: 1, click: "LEFT", icon: "f7:arrowtriangle_left"
      button row: 3, column: 3, click: "RIGHT", icon: "f7:arrowtriangle_right"
      button row: 3, column: 2, click: "ENTER", icon: "material:adjust"
    end
  end
end
```

Mixing positional and keyword arguments


```ruby
sitemaps.build do
  sitemap "remote" do
    buttongrid item: RCButton do
      button 1, 1, click: "BACK", icon: "f7:return"
      button 1, 2, click: "HOME", icon: "material:apps"
      button 1, 3, click: "YELLOW", icon: "f7:search"
      button 2, 2, click: "UP", icon: "f7:arrowtriangle_up"
      button 4, 2, click: "DOWN", icon: "f7:arrowtriangle_down"
      button 3, 1, click: "LEFT", icon: "f7:arrowtriangle_left"
      button 3, 3, click: "RIGHT", icon: "f7:arrowtriangle_right"
      button 3, 2, click: "ENTER", icon: "material:adjust"
    end
  end
end
```

openHAB 4.2+ supports assigning different items to buttons, along with additional features

```ruby
sitemaps.build do
  sitemap "remote" do
    buttongrid item: RCButton do
      button 1, 1, click: "BACK", icon: "f7:return"
      button 1, 2, click: "HOME", icon: "material:apps"
      button 1, 3, click: "YELLOW", icon: "f7:search", icon_color: "yellow"
      button 2, 2, click: "UP", icon: "f7:arrowtriangle_up"
      button 4, 2, click: "DOWN", icon: "f7:arrowtriangle_down"
      button 3, 1, click: "LEFT", icon: "f7:arrowtriangle_left"
      button 3, 3, click: "RIGHT", icon: "f7:arrowtriangle_right"
      button 3, 2, click: "ENTER", icon: "material:adjust", icon_color: "red"

      # These buttons will use the specified item, only supported in openHAB 4.2+
      button 4, 3, click: ON, icon: "switch-on", visibility: "TVPower!=ON", item: TVPower
      button 4, 3, click: OFF, icon: "switch-off", visibility: "TVPower==ON", item: TVPower
    end
  end
end
```