### PR TITLE
Initializing a `DateTimeType` without an argument should set it to now

### DIFF
--- a/lib/openhab/core/types/date_time_type.rb
+++ b/lib/openhab/core/types/date_time_type.rb
@@ -80,7 +80,10 @@ module OpenHAB
         # @param value [#to_zoned_date_time, #to_time, #to_str, #to_d, nil]
         #
         def initialize(value = nil)
-          if value.respond_to?(:to_zoned_date_time)
+          if value.nil?
+            super()
+            return
+          elsif value.respond_to?(:to_zoned_date_time)
             super(value.to_zoned_date_time)
             return
           elsif value.respond_to?(:to_time)

--- a/spec/openhab/core/types/date_time_type_spec.rb
+++ b/spec/openhab/core/types/date_time_type_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe OpenHAB::Core::Types::DateTimeType do
   let(:date2) { DateTimeType.new("2021-01-31T08:00:00+00:00") }
   let(:date3) { DateTimeType.new("2021-01-31T14:00:00+06:00") }
 
+  describe "#initialize" do
+    it "initializes to `now` if no argument is given" do
+      expect(DateTimeType.new.zoned_date_time.to_epoch_second).to be_within(1).of(ZonedDateTime.now.to_epoch_second)
+    end
+  end
+
   describe "math operations" do
     let(:date1) { DateTimeType.new("1970-01-31T08:00:00+0200") }
 


### PR DESCRIPTION
For some reason, `nil.respond_to?(:to_d)` equals true, which resulted in `DateTimeTime.new` => epoch instead of now.