### PR TITLE
Add Time#to_instant for convenience

### DIFF
--- a/lib/openhab/core_ext/ruby/time.rb
+++ b/lib/openhab/core_ext/ruby/time.rb
@@ -92,6 +92,11 @@ class Time
     to_java(java.time.ZonedDateTime)
   end
 
+  # @return [java.time.Instant]
+  def to_instant
+    to_java(java.time.Instant)
+  end
+
   #
   # Converts to a {ZonedDateTime} if `other`
   # is also convertible to a ZonedDateTime.

--- a/spec/openhab/core_ext/ruby/time_spec.rb
+++ b/spec/openhab/core_ext/ruby/time_spec.rb
@@ -59,4 +59,10 @@ RSpec.describe Time do
       expect(time.between?(time..)).to be true
     end
   end
+
+  describe "#to_instant" do
+    it "converts to Instant" do
+      expect(described_class.now.to_instant).to be_a(java.time.Instant)
+    end
+  end
 end


### PR DESCRIPTION
It seems that some APIs need an `Instant`. This allows us to use `Time.now.to_instant` as an alternative to `ZonedDateTime.now.to_instant`