### PR TITLE
Persistence: support direct arithmetics against PersistedState

### DIFF
--- a/lib/openhab/core/types/decimal_type.rb
+++ b/lib/openhab/core/types/decimal_type.rb
@@ -146,8 +146,8 @@ module OpenHAB
             #   elsif other.is_a?(java.math.BigDecimal)
             #     self.class.new(to_big_decimal.add(other))
             #   elsif other.respond_to?(:to_d)
-            #     result = to_d + other
-            #     # result could already be a QuantityType
+            #     result = to_d + other.to_d
+            #     # result could already be a NumericType
             #     result = self.class.new(result) unless result.is_a?(NumericType)
             #     result
             #   elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))
@@ -163,8 +163,8 @@ module OpenHAB
                 elsif other.is_a?(java.math.BigDecimal)
                   self.class.new(to_big_decimal.#{java_op}(other, java.math.MathContext::DECIMAL128))
                 elsif other.respond_to?(:to_d)
-                  result = to_d #{ruby_op} other
-                  # result could already be a QuantityType
+                  result = to_d #{ruby_op} other.to_d
+                  # result could already be a NumericType
                   result = self.class.new(result) unless result.is_a?(NumericType)
                   result
                 elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(to_d))

--- a/lib/openhab/core/types/quantity_type.rb
+++ b/lib/openhab/core/types/quantity_type.rb
@@ -179,6 +179,7 @@ module OpenHAB
           class_eval( # rubocop:disable Style/DocumentDynamicEvalDefinition https://github.com/rubocop/rubocop/issues/10179
             # def +(other)
             #   logger.trace("#{self} + #{other} (#{other.class})")
+            #   other = other.state if other.is_a?(Core::Items::Persistence::PersistedState)
             #   if other.is_a?(QuantityType)
             #     add_quantity(other)
             #   elsif (thread_unit = DSL.unit(dimension))
@@ -203,6 +204,7 @@ module OpenHAB
             <<~RUBY, __FILE__, __LINE__ + 1
               def #{ruby_op}(other)
                 logger.trace("\#{self} #{ruby_op} \#{other} (\#{other.class})")
+                other = other.state if other.is_a?(Core::Items::Persistence::PersistedState)
                 if other.is_a?(QuantityType)
                   #{java_op}_quantity(other)
                 elsif (thread_unit = DSL.unit(dimension))


### PR DESCRIPTION
Currently, adding up `PersistedState`s requires adding `.state` 

```ruby
    spot_prices = SpotPrice.all_states_between(start, start + 2.days)

    time_series = TimeSeries.new # the default policy is replace
    spot_prices.each do |spot_price|
      total_price = spot_price.state +
                    GridTariff.persisted_state(spot_price.timestamp).state +
                    SystemTariff.persisted_state(spot_price.timestamp).state +
                    TransmissionGridTariff.persisted_state(spot_price.timestamp).state +
                    ElectricityTax.persisted_state(spot_price.timestamp).state
      time_series.add(spot_price.timestamp, total_price)
    end
```



This PR makes this possible (only the relevant part shown here):

```ruby
total_price = spot_price +
                    GridTariff.persisted_state(spot_price.timestamp) +
                    SystemTariff.persisted_state(spot_price.timestamp) +
                    TransmissionGridTariff.persisted_state(spot_price.timestamp) +
                    ElectricityTax.persisted_state(spot_price.timestamp)
 
```

Is this a good idea or not?