### PR TITLE
make rake lint:yard fail on warning like github action

### DIFF
--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -16,7 +16,8 @@ namespace :lint do
 
   desc "YARD Docs"
   task :yard do
-    sh "yard stats -c --list-undoc"
+    sh("yard -c --no-cache --private --fail-on-warning --no-stats") &&
+      sh("yard stats -c --list-undoc")
   end
 
   desc "Execute all lint tests"


### PR DESCRIPTION
This kept tripping me up because running the local rake lint:yard didn't show the problem that the github action would otherwise catch.