### PR TITLE
Fix access to context variables in UI rules

### DIFF
--- a/lib/openhab/core/events/item_event.rb
+++ b/lib/openhab/core/events/item_event.rb
@@ -32,7 +32,7 @@ module OpenHAB
         # @since openHAB 4.1 for UI rules
         #
         def group
-          triggering_group = inputs&.[]("triggeringGroup") || $ctx&.[]("triggeringGroup")
+          triggering_group = inputs&.[]("triggeringGroup") || Core.ui_context&.[](:triggeringGroup)
           Items::Proxy.new(triggering_group) if triggering_group
         end
       end

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -1094,15 +1094,20 @@ module OpenHAB
     # @!visibility private
     ruby2_keywords def method_missing(method, *args)
       return super unless args.empty? && !block_given?
-      return super unless (context = Thread.current[:openhab_context]) && context.key?(method)
 
-      logger.trace("DSL#method_missing found context variable: '#{method}'")
-      context[method]
+      if (context = Thread.current[:openhab_context]) && context.key?(method)
+        logger.trace("DSL#method_missing found context variable: '#{method}'")
+        return context[method]
+      elsif Core.ui_context&.key?(method)
+        logger.trace("DSL#method_missing found UI context variable: '#{method}'")
+        return Core.ui_context[method]
+      end
+      super
     end
 
     # @!visibility private
     def respond_to_missing?(method, include_private = false)
-      Thread.current[:openhab_context]&.key?(method) || super
+      Thread.current[:openhab_context]&.key?(method) || Core.ui_context&.key?(method) || super
     end
   end
 end


### PR DESCRIPTION
#133 implemented context access for when UI rules/scripts are manually run/triggered. We didn't encounter any issues for that particular method of execution, because there is no trigger module ID involved.

In UI based rules, $ctx keys are prepended with the module id of the trigger that triggered the rule execution (e.g. item state change), so currently the library won't find a match for, e.g. `event` because it's stored as `$ctx["<moduleid>.event"]` 

It appears that nobody is using this library for UI based rules, otherwise we would've received bug reports/complaints.

