### PR TITLE
Support creating a rule in an initially disabled state

### DIFF
--- a/lib/openhab/core/rules/rule.rb
+++ b/lib/openhab/core/rules/rule.rb
@@ -112,6 +112,15 @@ module OpenHAB
         end
 
         #
+        # Check if the rule's status detail != `DISABLED`
+        #
+        # @return [true, false]
+        #
+        def enabled?
+          !disabled?
+        end
+
+        #
         # Checks if this rule has at least one of the given tags.
         #
         # (see Items::Item#tagged)

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -2134,7 +2134,11 @@ module OpenHAB
           added_rule.actions.first.configuration.put("type", "application/x-ruby")
           added_rule.actions.first.configuration.put("script", script) if script
 
-          process_on_load { |module_id| rule.execute(nil, { "module" => module_id }) }
+          if enabled
+            process_on_load { |module_id| rule.execute(nil, { "module" => module_id }) }
+          else
+            added_rule.disable
+          end
 
           added_rule
         end
@@ -2181,8 +2185,6 @@ module OpenHAB
             logger.warn "Rule '#{uid}' has no triggers, not creating rule"
           elsif !execution_blocks?
             logger.warn "Rule '#{uid}' has no execution blocks, not creating rule"
-          elsif !enabled
-            logger.trace { "Rule '#{uid}' marked as disabled, not creating rule." }
           else
             return true
           end

--- a/spec/openhab/dsl/rules/builder_spec.rb
+++ b/spec/openhab/dsl/rules/builder_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe OpenHAB::DSL::Rules::Builder do
     expect(spec_log_lines).to include(include("has no execution blocks, not creating rule"))
   end
 
+  it "can create a disabled rule" do
+    loaded = false
+    rule id: "disabled_rule" do
+      on_load
+      enabled false
+      run { loaded = true }
+    end
+
+    expect(loaded).to be false
+    expect(rules["disabled_rule"]).to be_disabled
+    rules["disabled_rule"].run
+    expect(loaded).to be false
+
+    rules["disabled_rule"].enable
+    rules["disabled_rule"].run
+    expect(loaded).to be true
+    expect(rules["disabled_rule"]).not_to be_disabled
+  end
+
   it "can access items from the rule block" do
     items.build do
       switch_item "lowerCaseSwitchItem"


### PR DESCRIPTION
Create the rule in a disabled state instead of not creating it at all, so it can be enabled in the future.