### PR TITLE
Sitemap updates not propagated to listeners

### DIFF
--- a/spec/openhab/core/sitemaps/provider_spec.rb
+++ b/spec/openhab/core/sitemaps/provider_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenHAB::Core::Sitemaps::Provider do
+  let(:model_listener) { org.openhab.core.model.core.ModelRepositoryChangeListener.impl { nil } }
+  let(:provider) { described_class.instance }
+
+  before { provider.addModelChangeListener(model_listener) }
+  after { provider.removeModelChangeListener(model_listener) }
+
+  describe "#add" do
+    it "notifies listeners with the correct name" do
+      allow(model_listener).to receive(:modelChanged)
+
+      sitemaps.build do
+        sitemap "test"
+      end
+
+      expect(model_listener).to have_received(:modelChanged)
+        .with("test.sitemap", org.openhab.core.model.core.EventType::ADDED)
+
+      expect(model_listener).to have_received(:modelChanged)
+        .with("test.sitemap", org.openhab.core.model.core.EventType::MODIFIED)
+    ensure
+      sitemaps.remove("test")
+    end
+  end
+
+  describe "#update" do
+    it "notifies listeners with the correct name" do
+      sitemaps.build do
+        sitemap "test"
+      end
+
+      expect(model_listener).not_to receive(:modelChanged)
+        .with("test.sitemap", org.openhab.core.model.core.EventType::ADDED)
+
+      expect(model_listener).to receive(:modelChanged)
+        .with("test.sitemap", org.openhab.core.model.core.EventType::MODIFIED)
+
+      sitemaps.build(update: true) do
+        sitemap "test"
+      end
+    ensure
+      sitemaps.remove("test")
+    end
+  end
+
+  describe "#remove" do
+    it "notifies listeners with the correct name" do
+      sitemaps.build do
+        sitemap "test"
+      end
+
+      expect(model_listener).to receive(:modelChanged)
+        .with("test.sitemap", org.openhab.core.model.core.EventType::REMOVED)
+
+      provider.remove("test")
+    end
+  end
+end


### PR DESCRIPTION
See: https://github.com/openhab/openhab-core/blob/8d54ccefef1ec06b16542bf28af5452742cfaba7/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java#L340

Without this fix, you'd have to refresh the ui (e.g. BasicUI) to "see" the change in the given example below. With the fix, BasicUI will automatically refresh.

```ruby
sitemaps.build do
  sitemap "test" do
    text label: "Old1"
    text label: "Old2"
  end
end

items.build { switch_item TestSwitch1 }

received_command(TestSwitch1) do
  # Recreate the sitemap completely
  sitemaps.build do
    sitemap "test" do
      text label: "New"
    end
  end
end
```

Steps:
- Load the above script, but don't send a command to TestSwitch1 yet.
- Load the sitemap in BasicUI / browser. It should show two text widgets Old1, Old2
- Now send a command to TestSwitch1, triggering the rule
- Switch to the BasicUI Window (don't refresh the page!). Before PR, it will still show Old1, Old2
- After PR, BasicUI will update itself without user having to refresh the page, and will show "New"
