### PR TITLE
DateTimeType implements Java's Comparable in openHAB 4.3

### DIFF
--- a/lib/openhab/core/types/date_time_type.rb
+++ b/lib/openhab/core/types/date_time_type.rb
@@ -18,7 +18,13 @@ module OpenHAB
         remove_method :==
 
         extend Forwardable
-        include Comparable
+
+        # @deprecated OH 4.2 DateTimeType implements Java's Comparable interface in openHAB 4.3
+        if OpenHAB::Core.version >= OpenHAB::Core::V4_3
+          include ComparableType
+        else
+          include Comparable
+        end
 
         #
         # Regex expression to identify strings defining a time in hours, minutes and optionally seconds


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/4364 broke `spec/openhab/core/types/date_time_type_spec.rb:32`
