### PR TITLE
Support space separator between date and time

### DIFF
--- a/lib/openhab/core/items/date_time_item.rb
+++ b/lib/openhab/core/items/date_time_item.rb
@@ -47,7 +47,15 @@ module OpenHAB
         def format_type(command)
           return command if command.is_a?(Types::DateTimeType)
           return Types::DateTimeType.new(command.to_zoned_date_time) if command.respond_to?(:to_zoned_date_time)
-          return Types::DateTimeType.new(DSL.try_parse_time_like(command.to_str)) if command.respond_to?(:to_str)
+
+          if command.respond_to?(:to_str)
+            command = command.to_str
+            begin
+              return Types::DateTimeType.new(DSL.try_parse_time_like(command))
+            rescue ArgumentError
+              return Types::DateTimeType.new(command)
+            end
+          end
 
           super
         end

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -1077,7 +1077,7 @@ module OpenHAB
       return string unless string.is_a?(String)
 
       exception = nil
-      [java.time.LocalTime, java.time.LocalDate, java.time.MonthDay, java.time.ZonedDateTime].each do |klass|
+      [java.time.LocalTime, java.time.LocalDate, java.time.MonthDay, java.time.ZonedDateTime, Time].each do |klass|
         return klass.parse(string)
       rescue ArgumentError => e
         exception ||= e

--- a/spec/openhab/core/items/date_time_item_spec.rb
+++ b/spec/openhab/core/items/date_time_item_spec.rb
@@ -29,4 +29,14 @@ RSpec.describe OpenHAB::Core::Items::DateTimeItem do
     item.update("3:30pm")
     expect(item.state).to eq LocalTime.parse("3:30pm").to_zoned_date_time
   end
+
+  it "can be updated by a string that looks like a date" do
+    item.update("2021-01-01")
+    expect(item.state).to eq LocalDate.parse("2021-01-01").to_zoned_date_time
+  end
+
+  it "can be updated by a string that looks like a date and time" do
+    item.update("2021-01-01 15:40Z")
+    expect(item.state).to eq ZonedDateTime.parse("2021-01-01T15:40Z")
+  end
 end


### PR DESCRIPTION
Support `DateTimeType.new("2020-01-01 12:30")` as well as `DateTimeItem1.update("2020-01-01 12:30")` for all versions of openHAB.

See: https://github.com/openhab/openhab-core/pull/4370 and DateTimeType also supports parsing a string containing epoch, so let it try parsing the string too.