### PR TITLE
use dscalarm binding for tests

### DIFF
--- a/rakelib/docs.rake
+++ b/rakelib/docs.rake
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require "yard"
+begin
+  require "yard"
+rescue LoadError
+  return
+end
 
 namespace :docs do
   yard_dir = File.join("docs", "yard")

--- a/spec/openhab/core/things/thing_spec.rb
+++ b/spec/openhab/core/things/thing_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe OpenHAB::Core::Things::Thing do
     end
 
     it "returns true for bridges" do
-      install_addon "binding-mqtt", ready_markers: "openhab.xmlThingTypes"
-      things.build { bridge "mqtt:broker:mosquitto", "MQTT Broker" }
+      install_addon "binding-dscalarm", ready_markers: "openhab.xmlThingTypes"
+      things.build { bridge "dscalarm:tcpserver:panel", "Alarm Panel" }
 
-      expect(things["mqtt:broker:mosquitto"]).to be_bridge
+      expect(things["dscalarm:tcpserver:panel"]).to be_bridge
     end
   end
 end

--- a/spec/openhab/dsl/things/builder_spec.rb
+++ b/spec/openhab/dsl/things/builder_spec.rb
@@ -328,22 +328,22 @@ RSpec.describe OpenHAB::DSL::Things::Builder do
   end
 
   describe "#bridge" do
-    before { install_addon "binding-mqtt", ready_markers: "openhab.xmlThingTypes" }
+    before { install_addon "binding-dscalarm", ready_markers: "openhab.xmlThingTypes" }
 
     it "can create a bridge" do
       things.build do
-        bridge "mqtt:broker:mybroker", config: { host: "127.0.0.1" }
+        bridge "dscalarm:tcpserver:panel", config: { ipAddress: "127.0.0.1" }
       end
     end
 
     it "can create nested things" do
       things.build do
-        bridge "mqtt:broker:mybroker", config: { host: "127.0.0.1" } do
-          thing "mqtt:topic:mytopic", config: { stateTopic: "mything/mytopic" }
+        bridge "dscalarm:tcpserver:panel", config: { ipAddress: "127.0.0.1" } do
+          thing "dscalarm:zone:front_door", config: { zoneNumber: 1 }
         end
       end
 
-      expect(things["mqtt:topic:mytopic"].bridge_uid).to eq "mqtt:broker:mybroker"
+      expect(things["dscalarm:zone:front_door"].bridge_uid).to eq "dscalarm:tcpserver:panel"
     end
   end
 end


### PR DESCRIPTION
instead of MQTT, which recently got a new dependency that's not installing for some reason