### PR TITLE
special case mired unit dimension inference in items builder

### DIFF
--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -554,6 +554,7 @@ module OpenHAB
         def unit=(unit)
           @unit = unit
 
+          self.dimension ||= "Temperature" if unit&.to_s == "mired"
           self.dimension ||= unit && org.openhab.core.types.util.UnitUtils.parse_unit(unit)&.then do |u|
             org.openhab.core.types.util.UnitUtils.get_dimension_name(u)
           end

--- a/spec/openhab/dsl/items/builder_spec.rb
+++ b/spec/openhab/dsl/items/builder_spec.rb
@@ -346,9 +346,12 @@ RSpec.describe OpenHAB::DSL::Items::Builder do
   it "can infer the dimension from the explicit unit for a number item" do
     items.build do
       number_item "MyNumberItem", unit: "kW"
+      number_item "ColorTempItem", unit: "mired"
     end
     expect(MyNumberItem.dimension.ruby_class).to be javax.measure.quantity.Power
     expect(MyNumberItem.metadata["unit"].value).to eql "kW"
+    expect(ColorTempItem.dimension.ruby_class).to be javax.measure.quantity.Temperature
+    expect(ColorTempItem.metadata["unit"].value).to eql "mired"
     if OpenHAB::Core.version >= OpenHAB::Core::V4_0
       expect(MyNumberItem.unit.to_s).to eql "kW"
       expect(MyNumberItem.state_description.pattern).to eql "%s %unit%"


### PR DESCRIPTION
mired is 1/Temperature, but the rest of openHAB treats it as Temperature, so special case it