### PR TITLE
 Improve errors when an item no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -810,7 +810,7 @@ Here is a non-exhaustive list of significant departures from the original gem:
 - {OpenHAB::Core::Events::ItemStateEvent} and {OpenHAB::Core::Events::ItemStateChangedEvent} now have full sets of predicate methods.
 - {OpenHAB::DSL::Rules::Terse terse rules} now have an `on_load` parameter.
 - {Item#all_groups Item#all_groups}, {Enumerable#all_members}, {Enumerable#groups}, {Enumerable#all_groups}.
-- {GenericItem#formatted_state GenericItem#formatted_state}.
+- {Item#formatted_state Item#formatted_state}.
 - {OpenHAB::DSL.transform} now available at top-level, like Rules DSL.
 - {Item#member_of? Item#member_of?}, {Item#tagged? Item#tagged?}.
 - {OpenHAB::DSL::Rules::BuilderDSL.watch watch} can now be used to monitor subdirectories

--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -158,7 +158,7 @@ module OpenHAB
         def lookup_entity(name, create_dummy_items: false)
           # make sure we have a nil return
           create_dummy_items = nil if create_dummy_items == false
-          lookup_item(name) || lookup_thing_const(name) || (create_dummy_items && Items::Proxy.new(name.to_sym))
+          lookup_item(name) || lookup_thing_const(name) || (create_dummy_items && Items::Proxy.new(name.to_s))
         end
 
         #

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -38,24 +38,6 @@ module OpenHAB
           def ===(other)
             other.is_a?(self)
           end
-
-          # @!visibility private
-          def item_states_event_builder
-            @item_states_event_builder ||=
-              OpenHAB::OSGi.service("org.openhab.core.io.rest.sse.internal.SseItemStatesEventBuilder")&.tap do |builder|
-                m = builder.class.java_class.get_declared_method("getDisplayState", Item, java.util.Locale)
-                m.accessible = true
-                builder.instance_variable_set(:@getDisplayState, m)
-                # Disable "singleton on non-persistent Java type"
-                original_verbose = $VERBOSE
-                $VERBOSE = nil
-                def builder.get_display_state(item)
-                  @getDisplayState.invoke(self, item, nil)
-                end
-              ensure
-                $VERBOSE = original_verbose
-              end
-          end
         end
         # rubocop:enable Naming/MethodName
 
@@ -89,21 +71,6 @@ module OpenHAB
           !raw_state.is_a?(Types::UnDefType)
         end
 
-        # @!attribute [r] formatted_state
-        #
-        # Format the item's state according to its state description
-        #
-        # This may include running a transformation.
-        #
-        # @return [String] The formatted state
-        #
-        # @example
-        #   logger.info(Exterior_WindDirection.formatted_state) # => "NE (36°)"
-        #
-        def formatted_state
-          GenericItem.item_states_event_builder.get_display_state(self)
-        end
-
         #
         # @!attribute [r] state
         # @return [State, nil]
@@ -123,124 +90,6 @@ module OpenHAB
         # @!method undef?
         #   Check if the item state == {UNDEF}
         #   @return [true,false]
-
-        #
-        # Send a command to this item
-        #
-        # When this method is chained after the {OpenHAB::DSL::Items::Ensure::Ensurable#ensure ensure}
-        # method, or issued inside an {OpenHAB::DSL.ensure_states ensure_states} block, or after
-        # {OpenHAB::DSL.ensure_states! ensure_states!} have been called,
-        # the command will only be sent if the item is not already in the same state.
-        #
-        # The similar method `command!`, however, will always send the command regardless of the item's state.
-        #
-        # @param [Command, #to_s] command command to send to the item.
-        #   When given a {Command} argument, it will be passed directly.
-        #   Otherwise, the result of `#to_s` will be parsed into a {Command}.
-        # @param [String, nil] source Optional string to identify what sent the event.
-        # @return [self, nil] nil when `ensure` is in effect and the item was already in the same state,
-        #   otherwise the item.
-        #
-        # @see DSL::Items::TimedCommand#command Timed Command
-        # @see OpenHAB::DSL.ensure_states ensure_states
-        # @see OpenHAB::DSL.ensure_states! ensure_states!
-        # @see DSL::Items::Ensure::Ensurable#ensure ensure
-        #
-        # @example Sending a {Command} to an item
-        #   MySwitch.command(ON) # The preferred method is `MySwitch.on`
-        #   Garage_Door.command(DOWN) # The preferred method is `Garage_Door.down`
-        #   SetTemperature.command 20 | "°C"
-        #
-        # @example Sending a plain number to a {NumberItem}
-        #   SetTemperature.command(22.5) # if it accepts a DecimalType
-        #
-        # @example Sending a string to a dimensioned {NumberItem}
-        #   SetTemperature.command("22.5 °C") # The string will be parsed and converted to a QuantityType
-        #
-        def command(command, source: nil)
-          command = format_command(command)
-          logger.trace { "Sending Command #{command} to #{name}" }
-          if source
-            Events.publisher.post(Events::ItemEventFactory.create_command_event(name, command, source.to_s))
-          else
-            $events.send_command(self, command)
-          end
-          Proxy.new(self)
-        end
-        alias_method :command!, :command
-
-        # not an alias to allow easier stubbing and overriding
-        def <<(command)
-          command(command)
-        end
-
-        # @!parse alias_method :<<, :command
-
-        # @!method refresh
-        #   Send the {REFRESH} command to the item
-        #   @return [Item] `self`
-
-        #
-        # Send an update to this item
-        #
-        # @param [State, #to_s, nil] state the state to update the item.
-        #   When given a {State} argument, it will be passed directly.
-        #   Otherwise, the result of `#to_s` will be parsed into a {State} first.
-        #   If `nil` is passed, the item will be updated to {NULL}.
-        # @return [self, nil] nil when `ensure` is in effect and the item was already in the same state,
-        #   otherwise the item.
-        #
-        # @example Updating to a {State}
-        #   DoorStatus.update(OPEN)
-        #   InsideTemperature.update 20 | "°C"
-        #
-        # @example Updating to {NULL}, the two following are equivalent:
-        #   DoorStatus.update(nil)
-        #   DoorStatus.update(NULL)
-        #
-        # @example Updating with a plain number
-        #   PeopleCount.update(5) # A plain NumberItem
-        #
-        # @example Updating with a string to a dimensioned {NumberItem}
-        #   InsideTemperature.update("22.5 °C") # The string will be parsed and converted to a QuantityType
-        #
-        def update(state)
-          state = format_update(state)
-          logger.trace { "Sending Update #{state} to #{name}" }
-          $events.post_update(self, state)
-          Proxy.new(self)
-        end
-        alias_method :update!, :update
-
-        # @!visibility private
-        def format_command(command)
-          command = format_type(command)
-          return command if command.is_a?(Types::Command)
-
-          command = command.to_s
-          org.openhab.core.types.TypeParser.parse_command(getAcceptedCommandTypes, command) || command
-        end
-
-        # @!visibility private
-        def format_update(state)
-          state = format_type(state)
-          return state if state.is_a?(Types::State)
-
-          state = state.to_s
-          org.openhab.core.types.TypeParser.parse_state(getAcceptedDataTypes, state) || StringType.new(state)
-        end
-
-        # formats a {Types::Type} to send to the event bus
-        # @!visibility private
-        def format_type(type)
-          # actual Type types can be sent directly without conversion
-          # make sure to use Type, because this method is used for both
-          # #update and #command
-          return type if type.is_a?(Types::Type)
-          return NULL if type.nil?
-
-          type.to_s
-        end
 
         #
         # @method time_series=(time_series)

--- a/lib/openhab/core/items/persistence.rb
+++ b/lib/openhab/core/items/persistence.rb
@@ -62,7 +62,7 @@ module OpenHAB
       #   logger.info("Max power usage today: #{max}, at: #{max.timestamp})
       #
       module Persistence
-        GenericItem.prepend(self)
+        Item.prepend(self)
 
         #
         # A wrapper for {org.openhab.core.persistence.HistoricItem HistoricItem} that delegates to its state.

--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -170,7 +170,7 @@ module OpenHAB
       # For more information, see {add}
       #
       module Semantics
-        GenericItem.include(self)
+        Item.include(self)
         GroupItem.extend(Forwardable)
         GroupItem.def_delegators :members, :equipments, :locations
 

--- a/lib/openhab/core/things/proxy.rb
+++ b/lib/openhab/core/things/proxy.rb
@@ -3,6 +3,9 @@
 require "delegate"
 require "forwardable"
 
+require_relative "thing"
+require_relative "thing_uid"
+
 module OpenHAB
   module Core
     module Things
@@ -18,8 +21,13 @@ module OpenHAB
                   Events::ThingRemovedEvent::TYPE].freeze
         # @!visibility private
         UID_METHOD = :uid
+        # @!visibility private
+        UID_TYPE = ThingUID
 
         include Core::Proxy
+
+        # @return [ThingUID]
+        attr_reader :uid
 
         # Returns the list of channels associated with this Thing
         #
@@ -41,57 +49,6 @@ module OpenHAB
         # @return [Thing::Properties] properties map
         def properties
           Thing::Properties.new(self)
-        end
-
-        #
-        # Set the proxy item (called by super)
-        #
-        def __setobj__(thing)
-          @uid = thing.uid
-        end
-
-        #
-        # Lookup thing from thing registry
-        #
-        def __getobj__
-          $things.get(@uid)
-        end
-
-        #
-        # Need to check if `self` _or_ the delegate is an instance of the
-        # given class
-        #
-        # So that {#==} can work
-        #
-        # @return [true, false]
-        #
-        # @!visibility private
-        def instance_of?(klass)
-          __getobj__.instance_of?(klass) || super
-        end
-
-        #
-        # Check if delegates are equal for comparison
-        #
-        # Otherwise items can't be used in Java maps
-        #
-        # @return [true, false]
-        #
-        # @!visibility private
-        def ==(other)
-          return __getobj__ == other.__getobj__ if other.instance_of?(Proxy)
-
-          super
-        end
-
-        #
-        # Non equality comparison
-        #
-        # @return [true, false]
-        #
-        # @!visibility private
-        def !=(other)
-          !(self == other) # rubocop:disable Style/InverseMethods
         end
       end
     end

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -27,7 +27,7 @@ module OpenHAB
         module Item
           include Ensurable
 
-          Core::Items::GenericItem.prepend(self)
+          Core::Items::Item.prepend(self)
 
           # If `ensure_states` is active (by block or chained method), then
           # check if this item is in the command's state before actually

--- a/lib/openhab/dsl/items/timed_command.rb
+++ b/lib/openhab/dsl/items/timed_command.rb
@@ -100,7 +100,7 @@ module OpenHAB
           attr_reader :timed_commands
         end
 
-        Core::Items::GenericItem.prepend(self)
+        Core::Items::Item.prepend(self)
         Core::Items::GroupItem.prepend(self)
 
         #

--- a/spec/openhab/core/items/proxy_spec.rb
+++ b/spec/openhab/core/items/proxy_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe OpenHAB::Core::Items::Proxy do
   # rubocop:enable Lint/UselessAssignment
 
   context "without a backing item" do
-    let(:item) { described_class.new(:MySwitch) }
+    let(:item) { described_class.new("MySwitch") }
 
     it "supports #name" do
-      expect(item.name).to eq "MySwitch"
+      expect(item.name).to eql "MySwitch"
     end
 
     it "pretends to be an item" do
@@ -94,9 +94,11 @@ RSpec.describe OpenHAB::Core::Items::Proxy do
       expect(item.members).to be_a(GroupItem::Members)
     end
 
-    it "doesn't respond to other Item methods" do
-      expect(item).not_to respond_to(:command)
-      expect { item.command }.to raise_error(NoMethodError)
+    it "responds to other Item methods, but doesn't respond to methods not on Item" do
+      expect(item).to respond_to(:command)
+      expect(item).not_to respond_to(:bogus)
+      expect { item.command }.to raise_error(OpenHAB::Core::Items::Proxy::StaleProxyError)
+      expect { item.bogus }.to raise_error(NoMethodError)
     end
 
     it "disappears when calling semantic predicates on an array" do


### PR DESCRIPTION
If a user keeps a ref to an item, and that item disappears, calling a method on that item will now raise a helpful StaleProxyError, instead of a NoMethodError on nil
   
The proxy code was significantly refactored, and Thing will also inherit the same stale proxy  I also removed the $things registry lookup on every access of a thing, using the same event subscriber mechanism as Item.
    
I also moved several methods from GenericItem to Item, so that Proxy can detect that those methods should exist even for dummy/stale items.