### PR TITLE
Use Units::MIRED instead of "mired" in HSBType

### DIFF
--- a/lib/openhab/core/types/hsb_type.rb
+++ b/lib/openhab/core/types/hsb_type.rb
@@ -255,8 +255,8 @@ module OpenHAB
             range_type = range.begin || range.end
             if !range_type.is_a?(QuantityType)
               range = Range.new(range.begin | "K", range.end | "K")
-            elsif range_type.unit.to_s == "mired"
-              cct |= "mired"
+            elsif range_type.unit == Units::MIRED
+              cct |= Units::MIRED
             end
           end
           return nil if range && !range.cover?(cct)


### PR DESCRIPTION
The change was introduced in 
https://github.com/openhab/openhab-core/pull/4433

