### PR TITLE
Update CI to openHAB 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,12 @@ jobs:
           (bin/yard stats -c | grep "100.00% documented")
           bin/validate_yard_links
 
-  openhab-matrix:
+  openhab-snapshot-date:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["3.4.5", "4.0.4", "4.1.3", "4.2.3", "4.3.0.M5", "4.3.0-SNAPSHOT"]
+        ["3.4.5", "4.0.4", "4.1.3", "4.2.3", "4.3.0", "5.0.0-SNAPSHOT"]
       snapshot_date: |
         ${{ steps.snapshot-date.outputs.SNAPSHOT_DATE }}
     steps:
@@ -81,12 +81,26 @@ jobs:
           echo SNAPSHOT_DATE=$(date -u +-%Y%m%d) >> $GITHUB_OUTPUT
 
   openhab-setup:
-    needs: openhab-matrix
+    needs: openhab-snapshot-date
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       matrix:
-        openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
+        include:
+          - java_version: 11
+            openhab_version: 3.4.5
+          - java_version: 17
+            openhab_version: 4.0.4
+          - java_version: 17
+            openhab_version: 4.1.3
+          - java_version: 17
+            openhab_version: 4.2.3
+          - java_version: 17
+            openhab_version: 4.3.0
+          - java_version: 21
+            openhab_version: 4.3.0
+          - java_version: 21
+            openhab_version: 5.0.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v4
       - name: Cache openHAB setup
@@ -94,7 +108,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tmp/
-          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
+          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
       - uses: ruby/setup-ruby@v1
         if: steps.cache.outputs.cache-hit != 'true'
         with:
@@ -103,7 +117,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
+          java-version: ${{ matrix.java_version }}
           java-package: jre
       - name: Setup openHAB
         if: steps.cache.outputs.cache-hit != 'true'
@@ -121,40 +135,49 @@ jobs:
           retention-days: 2
 
   rspec:
-    needs: [openhab-matrix, openhab-setup]
+    needs: [openhab-snapshot-date, openhab-setup]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       matrix:
-        openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
-        jruby_version: ["jruby-9.3.10.0", "jruby-9.4.9.0"]
-        exclude:
-          - openhab_version: 4.0.4
+        include:
+          - java_version: 11
             jruby_version: jruby-9.3.10.0
-          - openhab_version: 4.1.3
-            jruby_version: jruby-9.3.10.0
-          - openhab_version: 4.2.3
-            jruby_version: jruby-9.3.10.0
-          - openhab_version: 4.3.0.M5
-            jruby_version: jruby-9.3.10.0
-          - openhab_version: 4.3.0-SNAPSHOT
-            jruby_version: jruby-9.3.10.0
+            openhab_version: 3.4.5
+          - java_version: 17
+            jruby_version: jruby-9.4.2.0
+            openhab_version: 4.0.4
+          - java_version: 17
+            jruby_version: jruby-9.4.5.0
+            openhab_version: 4.1.3
+          - java_version: 17
+            jruby_version: jruby-9.4.6.0
+            openhab_version: 4.2.3
+          - java_version: 17
+            jruby_version: jruby-9.4.9.0
+            openhab_version: 4.3.0
+          - java_version: 21
+            jruby_version: jruby-9.4.9.0
+            openhab_version: 4.3.0
+          - java_version: 21
+            jruby_version: jruby-9.4.9.0
+            openhab_version: 5.0.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: ${{ matrix.java_version }}
+          java-package: jre
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.jruby_version }}
           bundler-cache: true
-      - uses: actions/setup-java@v4
-        with:
-          distribution: zulu
-          java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
-          java-package: jre
       - name: Restore openHAB setup
         uses: actions/cache@v4
         with:
           path: tmp/
-          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
+          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
       - name: RSpec
         run: bin/rspec --format progress --format html --out rspec.html
         timeout-minutes: 6
@@ -173,31 +196,41 @@ jobs:
           path: rspec.html
 
   cucumber:
-    needs: [openhab-matrix, openhab-setup]
+    needs: [openhab-snapshot-date, openhab-setup]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       matrix:
-        openhab_version: ${{ fromJson(needs.openhab-matrix.outputs.openhab_matrix) }}
-        exclude:
-          - openhab_version: 3.4.5
+        include:
+          - java_version: 17
+            openhab_version: 4.0.4
+          - java_version: 17
+            openhab_version: 4.1.3
+          - java_version: 17
+            openhab_version: 4.2.3
+          - java_version: 17
+            openhab_version: 4.3.0
+          - java_version: 21
+            openhab_version: 4.3.0
+          - java_version: 21
+            openhab_version: 5.0.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: ${{ matrix.java_version }}
+          java-package: jre
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
           rubygems: 3.4.22
-      - uses: actions/setup-java@v4
-        with:
-          distribution: zulu
-          java-version: ${{ startsWith(matrix.openhab_version, '4.') && '17' || '11' }}
-          java-package: jre
       - name: Restore openHAB setup
         uses: actions/cache@v4
         with:
           path: tmp/
-          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-matrix.outputs.snapshot_date || '' }}
+          key: openHAB-setup-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
       - name: Cucumber
         run: bin/rake features
         timeout-minutes: 4


### PR DESCRIPTION
Re-arrange the matrix to use includes instead of excludes, and run 4.3 against Java 17 _and_ 21. Also now that it's easier to list our exact configurations, run older openHABs with the JRuby version they shipped with.