### PR TITLE
Update to JRuby 9.4.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
             jruby_version: jruby-9.4.9.0
             openhab_version: 4.3.2
           - java_version: 21
-            jruby_version: jruby-9.4.10.0
+            jruby_version: jruby-9.4.11.0
             openhab_version: 5.0.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,11 @@ lockfile active: RUBY_VERSION >= "2.7" do
   # run tests
 
   gem "debug", "~> 1.9", require: false, platform: :mri
-  gem "irb", "~> 1.6"
+  gem "irb", "~> 1.6", platform: :mri
   gem "nokogiri", "~> 1.15"
-  gem "rubocop-inst", "~> 1.0"
-  gem "rubocop-rake", "~> 0.6"
-  gem "rubocop-rspec", "~> 2.11"
+  gem "rubocop-inst", "~> 1.0", platform: :mri
+  gem "rubocop-rake", "~> 0.6", platform: :mri
+  gem "rubocop-rspec", "~> 2.11", platform: :mri
 end
 
 lockfile "ruby-2.6", active: RUBY_VERSION < "2.7" do


### PR DESCRIPTION
[Jruby 9.4.11.0 requires psych 5.2.3](https://github.com/jruby/jruby/pull/8575), whereas prior versions require 5.1.x.
Something in the default Gemfile.lock requires psych too so picking one version or the other would cause a conflict with either jruby 9.4.11 or with the earlier versions.

~~Splitting jruby into its own lockfile seems like the cleanest option.~~ Not sure what's wrong there

Added `platform: :mri` to the incompatible gems instead