### PR TITLE
Use system timezone when converting from LocalDate/LocalTime to instant

### DIFF
--- a/lib/openhab/core_ext/java/local_date.rb
+++ b/lib/openhab/core_ext/java/local_date.rb
@@ -102,8 +102,7 @@ module OpenHAB
         #   during conversion. {ZonedDateTime.now} is assumed if not given.
         # @return [Instant]
         def to_instant(context = nil)
-          zone = context&.zone || java.time.ZoneOffset::UTC
-          at_start_of_day(zone).to_instant
+          to_zoned_date_time(context).to_instant
         end
       end
     end

--- a/lib/openhab/core_ext/java/local_time.rb
+++ b/lib/openhab/core_ext/java/local_time.rb
@@ -112,12 +112,15 @@ module OpenHAB
           context.with(self)
         end
 
+        #
+        # Converts the LocalTime (in the system timezone) to an Instant (in Zulu time).
+        #
         # @param [ZonedDateTime, nil] context
         #   A {ZonedDateTime} used to fill in missing fields
         #   during conversion. {ZonedDateTime.now} is assumed if not given.
         # @return [Instant]
+        #
         def to_instant(context = nil)
-          context ||= Instant.now.to_zoned_date_time
           to_zoned_date_time(context).to_instant
         end
       end

--- a/spec/openhab/core_ext/java/local_date_spec.rb
+++ b/spec/openhab/core_ext/java/local_date_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe java.time.LocalDate do
     it "works" do
       expect(date.to_instant).to eql Instant.parse("2022-11-09T00:00:00Z")
     end
+
+    it "takes on the system zone if no context" do
+      expect(date.to_instant).to eql ZonedDateTime.now.with(LocalTime.parse("00:00")).with(date).to_instant
+    end
   end
 
   describe "#succ" do

--- a/spec/openhab/core_ext/java/local_time_spec.rb
+++ b/spec/openhab/core_ext/java/local_time_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe java.time.LocalTime do
       context = ZonedDateTime.parse("1990-05-04T01:01:01+01:00")
       expect(time.to_instant(context)).to eql Instant.parse("1990-05-04T02:22:01Z")
     end
+
+    it "takes on the system zone if no context" do
+      expect(time.to_instant).to eql ZonedDateTime.now.with(time).to_instant
+    end
   end
 
   describe "#succ" do


### PR DESCRIPTION
This will fix the following problem:

```ruby
items.build { date_time_item DT1 }
DT1.update "7:30"
```

Previously, DT1 will interpret that as 7:30Z instead of 7:30 local time.