### PR TITLE
Support setting Thing property using hash-like syntax `[]=`

### DIFF
--- a/lib/openhab/core/emulate_hash.rb
+++ b/lib/openhab/core/emulate_hash.rb
@@ -113,7 +113,7 @@ module OpenHAB
       alias_method :update, :merge!
 
       # @!visibility private
-      def replace
+      def replace(hash)
         raise NotImplementedError
       end
 

--- a/lib/openhab/core/things/proxy.rb
+++ b/lib/openhab/core/things/proxy.rb
@@ -32,6 +32,17 @@ module OpenHAB
           Thing::ChannelsArray.new(self, super.to_a)
         end
 
+        # Returns the properties of this Thing
+        #
+        # @note This is defined on this class, and not on {Thing}, because
+        #   that's the interface and if you define it there, it will be hidden
+        #   by the method on ThingImpl.
+        #
+        # @return [Thing::Properties] properties map
+        def properties
+          Thing::Properties.new(self)
+        end
+
         #
         # Set the proxy item (called by super)
         #

--- a/lib/openhab/core/things/thing.rb
+++ b/lib/openhab/core/things/thing.rb
@@ -62,14 +62,21 @@ module OpenHAB
       #
       #   @example
       #     logger.info things["smtp:mail:local"].configuration["hostname"]
-      #     logger.info things["ipcamera:dahua:frontporch"].configuration["ipAddress"]
+      #     logger.info things["ipcamera:dahua:frontporch"].configuration[:ipAddress]
+      #
+      #   @example Changing Thing configuration
+      #     things["smtp:mail:local"].configuration[:hostname] = "smtp.gmail.com"
       #
       # @!attribute [r] properties
       #   Return the properties when available.
-      #   @return [Hash]
+      #   @return [Properties]
       #
       #   @example
       #     logger.info things["fronius:meter:mybridge:mymeter"].properties["modelId"]
+      #     logger.info things["fronius:meter:mybridge:mymeter"].properties[:modelId]
+      #
+      #   @example Changing Thing properties
+      #     things["lgwebos:WebOSTV:livingroom"].properties[:deviceId] = "e57ae675-aea0-4397-97bc-c39bea30c2ee"
       #
       module Thing
         # Array wrapper class to allow searching a list of channels
@@ -89,6 +96,30 @@ module OpenHAB
             return @thing.get_channel(index.to_str) if index.respond_to?(:to_str)
 
             super
+          end
+        end
+
+        # Properties wrapper class to allow setting Thing's properties with hash-like syntax
+        class Properties
+          include EmulateHash
+
+          def initialize(thing)
+            @thing = thing
+          end
+
+          # @!visibility private
+          def store(key, value)
+            @thing.set_property(key, value)
+          end
+
+          # @!visibility private
+          def replace(hash)
+            @thing.set_properties(hash)
+          end
+
+          # @!visibility private
+          def to_map
+            @thing.get_properties
           end
         end
 

--- a/spec/openhab/core/things/thing_spec.rb
+++ b/spec/openhab/core/things/thing_spec.rb
@@ -84,4 +84,21 @@ RSpec.describe OpenHAB::Core::Things::Thing do
       expect(things["dscalarm:tcpserver:panel"]).to be_bridge
     end
   end
+
+  describe "#properties" do
+    it "works" do
+      expect(thing.properties).to be_empty
+    end
+
+    it "supports setting properties" do
+      logger.warn thing.properties.class
+      thing.properties["test"] = "value"
+      expect(thing.properties["test"]).to eq "value"
+    end
+
+    it "supports indifferent keys" do
+      thing.properties["symbolic"] = "value"
+      expect(thing.properties[:symbolic]).to eq "value"
+    end
+  end
 end


### PR DESCRIPTION
Sometimes, we'd have to set a Thing's property because that's where the representationProperty resides, and it needs to be set when creating a Thing in order to avoid it being duplicated in the inbox.

The current method is to call `thing.set_property(key, value)`. This PR enables the syntax `thing.properties[key] = value`.