### PR TITLE
Thing Builder: Config entries not matching Thing's config description will be set as Thing's properties

### DIFF
--- a/spec/openhab/dsl/things/builder_spec.rb
+++ b/spec/openhab/dsl/things/builder_spec.rb
@@ -178,6 +178,13 @@ RSpec.describe OpenHAB::DSL::Things::Builder do
     expect(home.configuration.get("geolocation")).to eq "0,0"
   end
 
+  it "can set Thing properties" do
+    things.build do
+      thing "astro:sun:home", "Astro Sun Data", config: { property: "value" }
+    end
+    expect(things["astro:sun:home"].properties["property"]).to eql "value"
+  end
+
   context "with channels" do
     it "works" do
       things.build do


### PR DESCRIPTION
This PR enables setting the created Thing's properties directly in the Thing builder's `config` argument.

In other words, `config` can include both Thing's configuration and properties.
The configuration will be extracted from `config` based on ThingType's config description. Anything not in the config description will be set as properties.

This implementation is similar to the acceptance of discovery result done in core.

DiscoveryResultBuilder only has `withProperties`, and no `withConfiguration`. Both Configuration and Properties are added using `withProperties`, and the acceptance process splits them up based on Config Description.

See: https://github.com/openhab/openhab-core/blob/94bd3fcf7c0f21ffdef7d04880fcf222d26ffd93/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java#L572

There's also a somewhat related discussion here: https://community.openhab.org/t/binding-configuration-text-files-and-setting-properties/162404/12