### PR TITLE
Support Date/Time operations against Time QuantityType

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1163,7 +1163,22 @@ Time.at(1669684403)
 # Convert Epoch second to ZonedDateTime
 Time.at(1669684403).to_zoned_date_time
 # or
-java.time.Instant.of_epoch_second(1669684403).at_zone(ZoneId.system_default)
+Instant.of_epoch_second(1669684403).at_zone(ZoneId.system_default)
+```
+
+##### Time-based QuantityType <!-- omit from toc -->
+
+QuantityType objects with time dimension work like a Duration in arithmetic operations.
+They can be compared, added, and subtracted against Duration objects, and added/subtracted from Ruby and Java Date/Time-like objects.
+
+```java
+Number:Time Pump_Total_Runtime "Total Pump runtime today"
+```
+
+```ruby
+if Pump_Total_Runtime.state >= 8.hours
+  logger.info "The Pump has been running for 8 hours or more today"
+end
 ```
 
 #### Ranges <!-- omit from toc -->

--- a/lib/openhab/core_ext/java/local_date.rb
+++ b/lib/openhab/core_ext/java/local_date.rb
@@ -26,7 +26,7 @@ module OpenHAB
 
         # @!scope instance
 
-        # @param [TemporalAmount, LocalDate, Numeric] other
+        # @param [TemporalAmount, LocalDate, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as days.
         # @return [LocalDate] If other is a TemporalAmount or Numeric
         # @return [Period] If other is a LocalDate
@@ -42,12 +42,14 @@ module OpenHAB
             minus_days(other.to_days)
           when Numeric
             minus_days(other.ceil)
+          when QuantityType
+            minus_days(other.to_temporal_amount.to_days)
           else
             minus(other)
           end
         end
 
-        # @param [TemporalAmount, Numeric] other
+        # @param [TemporalAmount, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as days.
         # @return [LocalDate]
         def +(other)
@@ -56,6 +58,8 @@ module OpenHAB
             plus_days(other.to_days)
           when Numeric
             plus_days(other.to_i)
+          when QuantityType
+            plus_days(other.to_temporal_amount.to_days)
           else
             plus(other)
           end

--- a/lib/openhab/core_ext/java/local_time.rb
+++ b/lib/openhab/core_ext/java/local_time.rb
@@ -67,23 +67,25 @@ module OpenHAB
           end
         end
 
-        # @param [TemporalAmount, Numeric] other
+        # @param [TemporalAmount, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as seconds.
         # @return [LocalTime]
         def -(other)
           return minus(other.seconds) if other.is_a?(Numeric)
           return self if other.is_a?(Period)
 
+          other = other.to_temporal_amount if other.is_a?(QuantityType)
           minus(other)
         end
 
-        # @param [TemporalAmount, Numeric] other
+        # @param [TemporalAmount, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as seconds.
         # @return [LocalTime]
         def +(other)
           return plus(other.seconds) if other.is_a?(Numeric)
           return self if other.is_a?(Period)
 
+          other = other.to_temporal_amount if other.is_a?(QuantityType)
           plus(other)
         end
 

--- a/lib/openhab/core_ext/java/period.rb
+++ b/lib/openhab/core_ext/java/period.rb
@@ -36,6 +36,7 @@ module OpenHAB
         # @return [Integer, nil]
         def <=>(other)
           return to_i <=> other if other.is_a?(Numeric)
+          return to_i <=> other.to_i if other.is_a?(Duration)
 
           super
         end
@@ -43,11 +44,13 @@ module OpenHAB
         #
         # Convert `self` and `other` to {Duration}, if `other` is a Numeric
         #
-        # @param [Numeric] other
+        # @param [Numeric, Duration] other
         # @return [Array, nil]
         #
         def coerce(other)
-          [other.seconds, to_i.seconds] if other.is_a?(Numeric)
+          return [other.seconds, to_i.seconds] if other.is_a?(Numeric)
+
+          [other, to_i.seconds] if other.is_a?(Duration)
         end
 
         {
@@ -55,11 +58,11 @@ module OpenHAB
           minus: :-
         }.each do |java_op, ruby_op|
           # def +(other)
-          #   if other.is_a?(Period)
+          #   if other.is_a?(Period) || other.is_a?(Duration)
           #     plus(other)
           #   elsif other.is_a?(Numeric)
           #     self + other.seconds
-          #   elsif other.respond_to?(:coerce) && (rhs, lhs = other.coerce(self))
+          #   elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(self))
           #     lhs + rhs
           #   else
           #     raise TypeError, "#{other.class} can't be coerced into Period"
@@ -71,7 +74,7 @@ module OpenHAB
                 #{java_op}(other)
               elsif other.is_a?(Numeric)
                 self #{ruby_op} other.seconds
-              elsif other.respond_to?(:coerce) && (rhs, lhs = other.coerce(self))
+              elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(self))
                 lhs #{ruby_op} rhs
               else
                 raise TypeError, "\#{other.class} can't be coerced into Period"
@@ -84,7 +87,7 @@ module OpenHAB
         def *(other)
           if other.is_a?(Integer)
             multipliedBy(other)
-          elsif other.respond_to?(:coerce) && (rhs, lhs = other.coerce(self))
+          elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(self))
             lhs * rhs
           else
             raise TypeError, "#{other.class} can't be coerced into Period"

--- a/lib/openhab/core_ext/java/temporal_amount.rb
+++ b/lib/openhab/core_ext/java/temporal_amount.rb
@@ -28,6 +28,11 @@ module OpenHAB
         def inspect
           to_s
         end
+
+        # @return [self]
+        def to_temporal_amount
+          self
+        end
       end
     end
   end

--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -39,27 +39,33 @@ module OpenHAB
         # @return [Month]
         alias_method :to_month, :month
 
-        # @param [TemporalAmount, #to_zoned_date_time, Numeric] other
+        # @param [TemporalAmount, #to_zoned_date_time, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as seconds.
         # @return [Duration] If other responds to #to_zoned_date_time
-        # @return [ZonedDateTime] If other is a TemporalAmount
+        # @return [ZonedDateTime] If other is a TemporalAmount or a Time QuantityType
         def -(other)
           if other.respond_to?(:to_zoned_date_time)
             java.time.Duration.between(other.to_zoned_date_time, self)
           elsif other.is_a?(Numeric)
             minus(other.seconds)
+          elsif other.is_a?(QuantityType)
+            minus(other.to_temporal_amount)
           else
             minus(other)
           end
         end
 
-        # @param [TemporalAmount, Numeric] other
+        # @param [TemporalAmount, Numeric, QuantityType] other
         #   If other is a Numeric, it's interpreted as seconds.
         # @return [ZonedDateTime]
         def +(other)
-          return plus(other.seconds) if other.is_a?(Numeric)
-
-          plus(other)
+          if other.is_a?(Numeric)
+            plus(other.seconds)
+          elsif other.is_a?(QuantityType)
+            plus(other.to_temporal_amount)
+          else
+            plus(other)
+          end
         end
 
         #

--- a/lib/openhab/core_ext/ruby/date.rb
+++ b/lib/openhab/core_ext/ruby/date.rb
@@ -12,11 +12,11 @@ class Date
   #
   # Extends {#+} to allow adding a {java.time.temporal.TemporalAmount TemporalAmount}
   #
-  # @param [java.time.temporal.TemporalAmount] other
-  # @return [LocalDate] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
+  # @param [java.time.temporal.TemporalAmount, QuantityType] other
+  # @return [LocalDate] If other is a {java.time.temporal.TemporalAmount TemporalAmount} or a Time {QuantityType}
   #
   def plus_with_temporal(other)
-    return to_local_date + other if other.is_a?(java.time.temporal.TemporalAmount)
+    return to_local_date + other.to_temporal_amount if other.respond_to?(:to_temporal_amount)
 
     plus_without_temporal(other)
   end
@@ -26,13 +26,14 @@ class Date
   #
   # Extends {#-} to allow subtracting a {java.time.temporal.TemporalAmount TemporalAmount}
   #
-  # @param [java.time.temporal.TemporalAmount] other
-  # @return [LocalDate] If other is a {java.time.temporal.TemporalAmount TemporalAmount}
+  # @param [java.time.temporal.TemporalAmount, QuantityType] other
+  # @return [LocalDate] If other is a {java.time.temporal.TemporalAmount TemporalAmount} or a Time {QuantityType}
   #
   def minus_with_temporal(other)
-    case other
-    when java.time.temporal.TemporalAmount, java.time.LocalDate
+    if other.instance_of?(java.time.LocalDate)
       to_local_date - other
+    elsif other.respond_to?(:to_temporal_amount)
+      to_local_date - other.to_temporal_amount
     else
       minus_without_temporal(other)
     end

--- a/lib/openhab/core_ext/ruby/date_time.rb
+++ b/lib/openhab/core_ext/ruby/date_time.rb
@@ -15,7 +15,7 @@ class DateTime < Date
 
   # (see Time#plus_with_temporal)
   def plus_with_temporal(other)
-    return to_zoned_date_time + other if other.is_a?(java.time.temporal.TemporalAmount)
+    return to_zoned_date_time + other.to_temporal_amount if other.respond_to?(:to_temporal_amount)
 
     plus_without_temporal(other)
   end
@@ -24,7 +24,7 @@ class DateTime < Date
 
   # (see Time#minus_with_temporal)
   def minus_with_temporal(other)
-    return to_zoned_date_time - other if other.is_a?(java.time.temporal.TemporalAmount)
+    return to_zoned_date_time - other.to_temporal_amount if other.respond_to?(:to_temporal_amount)
 
     # Exclude subtracting against the same class
     if other.respond_to?(:to_zoned_date_time) && !other.is_a?(self.class)

--- a/lib/openhab/core_ext/ruby/time.rb
+++ b/lib/openhab/core_ext/ruby/time.rb
@@ -18,7 +18,7 @@ class Time
   # @return [Time] If other is a Numeric
   #
   def plus_with_temporal(other)
-    return to_zoned_date_time + other if other.is_a?(java.time.temporal.TemporalAmount)
+    return to_zoned_date_time + other.to_temporal_amount if other.respond_to?(:to_temporal_amount)
 
     plus_without_temporal(other)
   end
@@ -53,7 +53,7 @@ class Time
   # @return [Float] If other is a Time
   #
   def minus_with_temporal(other)
-    return to_zoned_date_time - other if other.is_a?(java.time.temporal.TemporalAmount)
+    return to_zoned_date_time - other.to_temporal_amount if other.respond_to?(:to_temporal_amount)
 
     # Exclude subtracting against the same class
     if other.respond_to?(:to_zoned_date_time) && !other.is_a?(self.class)

--- a/spec/openhab/core_ext/java/duration_spec.rb
+++ b/spec/openhab/core_ext/java/duration_spec.rb
@@ -10,18 +10,81 @@ RSpec.describe Duration do
     expect(5.5.hours).to be_a(described_class)
   end
 
-  it "is comparable to numeric" do
-    expect(5.seconds).to eq 5
-    expect(5.seconds).to eq 5
+  describe "comparisons" do
+    it "works with numeric" do
+      expect(5.seconds).to eq 5
+      expect(1.minute).to eq 60
+      expect(5.seconds < 6).to be true
+      expect(5.seconds > 6).to be false
+      expect(5.seconds > 4).to be true
+      expect(5.seconds < 4).to be false
+    end
+
+    it "works with other Durations" do
+      expect(60.seconds).to eq 1.minute
+      expect(5.seconds < 6.seconds).to be true
+      expect(5.seconds > 6.seconds).to be false
+      expect(5.seconds > 4.seconds).to be true
+      expect(5.seconds < 4.seconds).to be false
+    end
+
+    it "works with Time QuantityType" do
+      expect(QuantityType.new("5 s") == 5.seconds).to be true
+      expect(QuantityType.new("1 min") == 60.seconds).to be true
+      expect(QuantityType.new("5 s") < 6.seconds).to be true
+      expect(QuantityType.new("5 s") > 6.seconds).to be false
+      expect(QuantityType.new("5 s") > 4.seconds).to be true
+      expect(QuantityType.new("5 s") < 4.seconds).to be false
+
+      expect(5.seconds == QuantityType.new("5 s")).to be true
+      expect(60.seconds == QuantityType.new("1 min")).to be true
+      expect(6.seconds > QuantityType.new("5 s")).to be true
+      expect(6.seconds < QuantityType.new("5 s")).to be false
+      expect(4.seconds < QuantityType.new("5 s")).to be true
+      expect(4.seconds > QuantityType.new("5 s")).to be false
+    end
   end
 
-  it "is addable and subtractable" do
-    expect(60.seconds + 5).to eql 65.seconds
-    expect(5 + 60.seconds).to eql 65.seconds
-    expect(1.hour + 5.minutes).to eql 65.minutes
-    expect(1.hour - 5.minutes).to eql 55.minutes
-    expect(60.seconds - 5).to eql 55.seconds
-    expect(60 - 5.seconds).to eql 55.seconds
+  describe "math operations" do
+    describe "additions and subtractions" do
+      it "works with other Duration" do
+        expect(1.hour + 5.minutes).to eql 65.minutes
+        expect(1.hour - 5.minutes).to eql 55.minutes
+      end
+
+      it "works with Period and returns a Duration" do
+        expect(5.hours + Period.of_days(1)).to eql 29.hours
+        expect(25.hours - Period.of_days(1)).to eql 1.hours
+        expect(Period.of_days(1) + 5.hours).to eql 29.hours
+        expect(Period.of_days(1) - 5.hours).to eql 19.hours
+      end
+
+      it "works with Numeric" do
+        expect(60.seconds + 5).to eql 65.seconds
+        expect(5 + 60.seconds).to eql 65.seconds
+        expect(60.seconds - 5).to eql 55.seconds
+        expect(60 - 5.seconds).to eql 55.seconds
+      end
+
+      it "works with Time QuantityType and returns a Duration" do
+        expect(1.second + QuantityType.new("5 s")).to eql 6.seconds
+        expect(5.seconds - QuantityType.new("1 s")).to eql 4.seconds
+      end
+
+      it "Time QuantityType works with Duration and returns a QuantityType" do
+        expect(QuantityType.new("5 s") + 1.second).to eql QuantityType.new("6 s")
+        expect(QuantityType.new("5 s") - 1.second).to eql QuantityType.new("4 s")
+      end
+    end
+
+    describe "multiplications and divisions" do
+      it "works with Numeric" do
+        expect(5.minutes * 2).to eql 10.minutes
+        expect(5.minutes / 2).to eql 2.5.minutes
+        expect(5.minutes * 2.5).to eql 12.5.minutes
+        expect(5.minutes / 2.5).to eql 2.minutes
+      end
+    end
   end
 
   describe "#to_i" do

--- a/spec/openhab/core_ext/java/local_date_spec.rb
+++ b/spec/openhab/core_ext/java/local_date_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe java.time.LocalDate do
       expect(date + 24.hours).to eql java.time.LocalDate.parse("2022-11-10")
     end
 
+    it "works with a Time QuantityType" do
+      expect(date + QuantityType.new("1 d")).to eql java.time.LocalDate.parse("2022-11-10")
+    end
+
     it "works with integers" do
       expect(date + 1).to eql java.time.LocalDate.parse("2022-11-10")
     end
@@ -26,6 +30,10 @@ RSpec.describe java.time.LocalDate do
 
     it "works with Duration" do
       expect(date - 24.hours).to eql java.time.LocalDate.parse("2022-11-08")
+    end
+
+    it "works with a Time QuantityType" do
+      expect(date - QuantityType.new("1 d")).to eql java.time.LocalDate.parse("2022-11-08")
     end
 
     it "works with integers" do
@@ -76,7 +84,8 @@ RSpec.describe java.time.LocalDate do
 
   describe "#to_instant" do
     it "works" do
-      expect(date.to_instant).to eql Instant.parse("2022-11-09T00:00:00Z")
+      context = ZonedDateTime.parse("1990-05-04T00:00:00Z")
+      expect(date.to_instant(context)).to eql Instant.parse("2022-11-09T00:00:00Z")
     end
 
     it "takes on the system zone if no context" do

--- a/spec/openhab/core_ext/java/local_time_spec.rb
+++ b/spec/openhab/core_ext/java/local_time_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe java.time.LocalTime do
       expect(time + 2.hours).to eql LocalTime.parse("05:22:01")
     end
 
+    it "works with a Time QuantityType" do
+      expect(time + QuantityType.new("2 h")).to eql LocalTime.parse("05:22:01")
+    end
+
     it "works with integers" do
       expect(time + 1).to eql LocalTime.parse("03:22:02")
     end
@@ -47,6 +51,10 @@ RSpec.describe java.time.LocalTime do
 
     it "works with a Duration" do
       expect(time - 2.hours).to eql LocalTime.parse("01:22:01")
+    end
+
+    it "works with a Time QuantityType" do
+      expect(time - QuantityType.new("2 h")).to eql LocalTime.parse("01:22:01")
     end
 
     it "works with integers" do

--- a/spec/openhab/core_ext/java/zoned_date_time_spec.rb
+++ b/spec/openhab/core_ext/java/zoned_date_time_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe java.time.ZonedDateTime do
       now = described_class.now
       expect((now + 5).to_i).to be(now.to_i + 5)
     end
+
+    it "works with Time QuantityType" do
+      now = described_class.now
+      expect((now + QuantityType.new("5 s")).to_i).to be(now.to_i + 5)
+    end
   end
 
   describe "#-" do
@@ -38,6 +43,12 @@ RSpec.describe java.time.ZonedDateTime do
     it "works with integers" do
       now = described_class.now
       expect((now - 5).to_i).to be(now.to_i - 5)
+    end
+
+    it "works with Time QuantityType" do
+      now = described_class.now
+      expect((now - QuantityType.new("5 s"))).to be_a described_class
+      expect((now - QuantityType.new("5 s")).to_i).to be(now.to_i - 5)
     end
 
     it "returns a duration for another ZonedDateTime instance" do

--- a/spec/openhab/core_ext/ruby/date_spec.rb
+++ b/spec/openhab/core_ext/ruby/date_spec.rb
@@ -2,9 +2,16 @@
 
 RSpec.describe Date do
   describe "#+" do
-    it "works with Period" do
+    it "works with Period and returns a LocalDate" do
       now = described_class.today
       expect(now + 1.day).to eq(now + 1)
+      expect(now + 1.day).to be_a(java.time.LocalDate)
+    end
+
+    it "works with Time QuantityType and returns a LocalDate" do
+      now = described_class.today
+      expect(now + QuantityType.new("1 d")).to eq(now + 1)
+      expect(now + QuantityType.new("1 d")).to be_a(java.time.LocalDate)
     end
   end
 
@@ -22,6 +29,13 @@ RSpec.describe Date do
       result = now - ld
       expect(result).to eq(1.day)
       expect(result).to be_a(java.time.Period)
+    end
+
+    it "works with Time QuantityType and returns a LocalDate" do
+      now = described_class.today
+      result = now - QuantityType.new("1 d")
+      expect(result).to eq(now - 1)
+      expect(result).to be_a(java.time.LocalDate)
     end
 
     it "works with Numeric and returns a Date" do

--- a/spec/openhab/core_ext/ruby/time_spec.rb
+++ b/spec/openhab/core_ext/ruby/time_spec.rb
@@ -2,9 +2,25 @@
 
 RSpec.describe Time do
   describe "#+" do
-    it "works with Duration" do
+    it "works with Duration and returns a ZonedDateTime" do
       now = described_class.now
-      expect(now + 1.minute).to eq(now + 60)
+      result = now + 1.minute
+      expect(result).to eq(now + 60)
+      expect(result).to be_a(java.time.ZonedDateTime)
+    end
+
+    it "works with Time QuantityType and returns a ZonedDateTime" do
+      now = described_class.now
+      result = now + QuantityType.new("1 min")
+      expect(result).to eq(now + 60)
+      expect(result).to be_a(java.time.ZonedDateTime)
+    end
+
+    it "works with Numeric and returns a Time" do
+      Timecop.freeze
+      result = described_class.now + 60
+      expect(result).to eq 60.seconds.from_now
+      expect(result).to be_a(described_class)
     end
   end
 
@@ -12,6 +28,13 @@ RSpec.describe Time do
     it "works with Duration and returns a ZonedDateTime" do
       now = described_class.now
       result = now - 1.minute
+      expect(result).to eq(now - 60)
+      expect(result).to be_a(java.time.ZonedDateTime)
+    end
+
+    it "works with Time QuantityType and returns a ZonedDateTime" do
+      now = described_class.now
+      result = now - QuantityType.new("1 min")
       expect(result).to eq(now - 60)
       expect(result).to be_a(java.time.ZonedDateTime)
     end


### PR DESCRIPTION
Aiming to support including Time `QuantityType` in arithmetic operations (+/-, comparisons) against Duration and Date/Time. 

Some example usage:
```ruby
NumberTimeItem.state > 1.hour
ZonedDateTime.now + NumberTimeItem.state
```

`Period` isn't specifically treated as thoroughly in this PR, since I'm not sure it's used all that often.

