### PR TITLE
Add `GenericItem#was`, `#was?`, `#was_xxx?` predicates, document `Item#last_state`, `#last_state_change`, and `#last_state_update` methods

### DIFF
--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -13,6 +13,8 @@ module OpenHAB
     V4_2 = Gem::Version.new("4.2.0").freeze
     # @!visibility private
     V4_3 = Gem::Version.new("4.3.0").freeze
+    # @!visibility private
+    V5_0 = Gem::Version.new("5.0.0").freeze
 
     # @return [Gem::Version] Returns the current openHAB version as a Gem::Version object
     #   Note, this strips off snapshots, milestones and RC versions and returns the release version.

--- a/lib/openhab/core/items.rb
+++ b/lib/openhab/core/items.rb
@@ -49,6 +49,10 @@ module OpenHAB
               def #{state_predicate}                                                  # def on?
                 raw_state.as(#{state.class.java_class.simple_name}).equal?(#{state})  #   raw_state.as(OnOffType) == ON
               end                                                                     # end
+
+              def was_#{state_predicate}                                              # def was_on?
+                last_state.as(#{state.class.java_class.simple_name}).equal?(#{state}) #   last_state.as(OnOffType) == ON
+              end                                                                     # end
             RUBY
           end
         end

--- a/lib/openhab/core/items/call_item.rb
+++ b/lib/openhab/core/items/call_item.rb
@@ -13,6 +13,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [StringListType, nil]
       #
+      # @!attribute [r] was
+      #   @return [StringListType, nil]
+      #   @since openHAB 5.0
+      #
       class CallItem < GenericItem
         # @!visibility private
         def format_type(command)

--- a/lib/openhab/core/items/color_item.rb
+++ b/lib/openhab/core/items/color_item.rb
@@ -35,6 +35,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [HSBType, nil]
       #
+      # @!attribute [r] was
+      #   @return [HSBType, nil]
+      #   @since openHAB 5.0
+      #
       class ColorItem < DimmerItem
         # Make sure to do the String => HSBType conversion in Ruby,
         # where we add support for hex

--- a/lib/openhab/core/items/contact_item.rb
+++ b/lib/openhab/core/items/contact_item.rb
@@ -8,13 +8,17 @@ module OpenHAB
       java_import org.openhab.core.library.items.ContactItem
 
       #
-      #  A {ContactItem} can be used for sensors that return an "open" or
+      # A {ContactItem} can be used for sensors that return an "open" or
       # "closed" as a state.
       #
       # This is useful for doors, windows, etc.
       #
       # @!attribute [r] state
       #   @return [OpenClosedType, nil]
+      #
+      # @!attribute [r] was
+      #   @return [OpenClosedType, nil]
+      #   @since openHAB 5.0
       #
       # @example
       #   rule 'Log state of all doors on system startup' do
@@ -30,20 +34,29 @@ module OpenHAB
       #     end
       #   end
       #
+      # @!method open?
+      #   Check if the item state == {OPEN}
+      #   @return [true,false]
+      #
+      #   @example Log open contacts
+      #     Contacts.select(&:open?).each { |contact| logger.info("Contact #{contact.name} is open")}
+      #
+      # @!method closed?
+      #   Check if the item state == {CLOSED}
+      #   @return [true,false]
+      #
+      #   @example Log closed contacts
+      #     Contacts.select(&:closed?).each { |contact| logger.info("Contact #{contact.name} is closed")}
+      #
+      # @!method was_open?
+      #   Check if {#was} is {OPEN}
+      #   @return [true, false]
+      #
+      # @!method was_closed?
+      #   Check if {#was} is {CLOSED}
+      #   @return [true, false]
+      #
       class ContactItem < GenericItem
-        # @!method open?
-        #   Check if the item state == {OPEN}
-        #   @return [true,false]
-        #
-        # @example Log open contacts
-        #   Contacts.select(&:open?).each { |contact| logger.info("Contact #{contact.name} is open")}
-
-        # @!method closed?
-        #   Check if the item state == {CLOSED}
-        #   @return [true,false]
-        #
-        # @example Log closed contacts
-        #   Contacts.select(&:closed?).each { |contact| logger.info("Contact #{contact.name} is closed")}
       end
     end
   end

--- a/lib/openhab/core/items/date_time_item.rb
+++ b/lib/openhab/core/items/date_time_item.rb
@@ -13,6 +13,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [DateTimeType, nil]
       #
+      # @!attribute [r] was
+      #   @return [DateTimeType, nil]
+      #   @since openHAB 5.0
+      #
       # @example DateTime items can be updated and commanded with Ruby Time objects or Java ZonedDateTime objects
       #   Example_DateTimeItem << Time.now
       #   Example_DateTimeItem << ZonedDateTime.now

--- a/lib/openhab/core/items/dimmer_item.rb
+++ b/lib/openhab/core/items/dimmer_item.rb
@@ -15,6 +15,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [PercentType, nil]
       #
+      # @!attribute [r] was
+      #   @return [PercentType, nil]
+      #   @since openHAB 5.0
+      #
       # @example
       #   DimmerOne << DimmerOne.state - 5
       #   DimmerOne << 100 - DimmerOne.state

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -79,8 +79,43 @@ module OpenHAB
         #   [Ruby safe navigation operator `&.`](https://docs.ruby-lang.org/en/master/syntax/calling_methods_rdoc.html#label-Safe+Navigation+Operator)
         #   Use {#undef?} or {#null?} to check for those states.
         #
+        # @see was
+        #
         def state
           raw_state if state?
+        end
+
+        # @!method was_undef?
+        #   Check if {#was} is {UNDEF}
+        #   @return [true, false]
+
+        # @!method was_null?
+        #   Check if {#was} is {NULL}
+        #   @return [true, false]
+
+        #
+        # Check if the item's previous state was not `nil`, {UNDEF} or {NULL}
+        #
+        # @return [true, false]
+        #
+        # @since openHAB 5.0
+        #
+        def was?
+          !last_state.nil? && !last_state.is_a?(Types::UnDefType)
+        end
+
+        #
+        # @!attribute [r] was
+        #
+        # @return [State] The previous state of the item. nil if the item was never updated, or
+        #   if the item was updated to {NULL} or {UNDEF}.
+        # @since openHAB 5.0
+        #
+        # @see state
+        # @see Item#last_state
+        #
+        def was
+          last_state if was?
         end
 
         # @!method null?

--- a/lib/openhab/core/items/image_item.rb
+++ b/lib/openhab/core/items/image_item.rb
@@ -18,7 +18,11 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [RawType, nil]
       #
-      # @example Update from a base 64 encode image string
+      # @!attribute [r] was
+      #   @return [RawType, nil]
+      #   @since openHAB 5.0
+      #
+      # @example Update from a base 64 encoded image string
       #   Image.update("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=")
       #
       # @example Update from image bytes and mime type

--- a/lib/openhab/core/items/item.rb
+++ b/lib/openhab/core/items/item.rb
@@ -70,6 +70,18 @@ module OpenHAB
         # @!attribute [r] command_description
         #   @return [Types::CommandDescription, nil]
 
+        # @!attribute [r] last_state
+        #   @return [State] The previous state of the item.
+        #   @since openHAB 5.0
+
+        # @!attribute [r] last_state_change
+        #   @return [ZonedDateTime] The time of the last state change.
+        #   @since openHAB 5.0
+
+        # @!attribute [r] last_state_update
+        #   @return [ZonedDateTime] The time of the last state update.
+        #   @since openHAB 5.0
+
         #
         # The item's {GenericItem#label label} if one is defined, otherwise its {#name}.
         #
@@ -550,6 +562,12 @@ module OpenHAB
         # @return [String]
         def inspect
           s = "#<OpenHAB::Core::Items::#{type}Item#{type_details} #{name} #{label.inspect} state=#{raw_state.inspect}"
+          # @deprecated OH 4.3 Remove if guard when dropping support for OH 4.3
+          if respond_to?(:last_state)
+            s += " last_state=#{last_state.inspect}" if last_state
+            s += " last_state_update=#{last_state_update}" if last_state_update
+            s += " last_state_change=#{last_state_change}" if last_state_change
+          end
           s += " category=#{category.inspect}" if category
           s += " tags=#{tags.to_a.inspect}" unless tags.empty?
           s += " groups=#{group_names}" unless group_names.empty?

--- a/lib/openhab/core/items/location_item.rb
+++ b/lib/openhab/core/items/location_item.rb
@@ -16,6 +16,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [PointType, nil]
       #
+      # @!attribute [r] was
+      #   @return [PointType, nil]
+      #   @since openHAB 5.0
+      #
       # @example Send point commands
       #   Location << '30,20'   # latitude of 30, longitude of 20
       #   Location << '30,20,80' # latitude of 30, longitude of 20, altitude of 80

--- a/lib/openhab/core/items/number_item.rb
+++ b/lib/openhab/core/items/number_item.rb
@@ -25,6 +25,9 @@ module OpenHAB
       #   @return [javax.measure.Unit, nil]
       # @!attribute [r] state
       #   @return [DecimalType, QuantityType, nil]
+      # @!attribute [r] was
+      #   @return [DecimalType, QuantityType, nil]
+      #   @since openHAB 5.0
       #
       # @example Number Items can be selected in an enumerable with grep.
       #   # Get all NumberItems

--- a/lib/openhab/core/items/persistence.rb
+++ b/lib/openhab/core/items/persistence.rb
@@ -623,6 +623,7 @@ module OpenHAB
         #   Returns the time the item was last updated.
         #   @param [Symbol, String] service An optional persistence id instead of the default persistence service.
         #   @return [ZonedDateTime, nil] The timestamp of the last update
+        #   @see Item#last_state_update
 
         # @!method next_update(service = nil)
         #   Returns the first future update time of the item.
@@ -636,6 +637,7 @@ module OpenHAB
         #   @param [Symbol, String] service An optional persistence id instead of the default persistence service.
         #   @return [ZonedDateTime, nil] The timestamp of the last update
         #   @since openHAB 4.2
+        #   @see Item#last_state_change
 
         # @!method next_change(service = nil)
         #   Returns the first future change time of the item.
@@ -670,6 +672,8 @@ module OpenHAB
         #   @return [PersistedState, nil] the previous state or nil if no previous state could be found,
         #           or if the default persistence service is not configured or
         #           does not refer to a valid service
+        #
+        #   @see Item#last_state
 
         # @!method next_state(service = nil, skip_equal: false)
         #   Return the next state of the item

--- a/lib/openhab/core/items/player_item.rb
+++ b/lib/openhab/core/items/player_item.rb
@@ -10,71 +10,92 @@ module OpenHAB
       #
       # A {PlayerItem} allows control of a player, e.g. an audio player.
       #
-      # @!attribute [r] state
-      #   @return [PlayPauseType, RewindFastforwardType, nil]
-      #
       # @example Start playing on a player item
       #   Chromecast.play
       # @example Check if a player is paused
       #   logger.warn("#{item.name} is paused") if Chromecast.paused?
       #
+      # @!attribute [r] state
+      #   @return [PlayPauseType, RewindFastforwardType, nil]
+      #
+      # @!attribute [r] was
+      #   @return [PlayPauseType, RewindFastforwardType, nil]
+      #   @since openHAB 5.0
+      #
+      # @!method play?
+      #   Check if the item state == {PLAY}
+      #   @return [true,false]
+      #
+      # @!method paused?
+      #   Check if the item state == {PAUSE}
+      #   @return [true,false]
+      #
+      # @!method rewinding?
+      #   Check if the item state == {REWIND}
+      #   @return [true,false]
+      #
+      # @!method fast_forwarding?
+      #   Check if the item state == {FASTFORWARD}
+      #   @return [true,false]
+      #
+      # @!method was_playing?
+      #   Check if {#was} is {PLAY}
+      #   @return [true, false]
+      #
+      # @!method was_paused?
+      #   Check if {#was} is {PAUSE}
+      #   @return [true, false]
+      #
+      # @!method was_rewinding?
+      #   Check if {#was} is {REWIND}
+      #   @return [true, false]
+      #
+      # @!method was_fast_forwarding?
+      #   Check if {#was} is {FASTFORWARD}
+      #   @return [true, false]
+      #
+      # @!method play
+      #   Send the {PLAY} command to the item
+      #   @return [PlayerItem] `self`
+      #
+      # @!method play!
+      #   Send the {PLAY} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+      #   @return [PlayerItem] `self`
+      #
+      # @!method pause
+      #   Send the {PAUSE} command to the item
+      #   @return [PlayerItem] `self`
+      #
+      # @!method pause!
+      #   Send the {PAUSE} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+      #   @return [PlayerItem] `self`
+      #
+      # @!method rewind
+      #   Send the {REWIND} command to the item
+      #   @return [PlayerItem] `self`
+      #
+      # @!method rewind!
+      #   Send the {REWIND} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+      #   @return [PlayerItem] `self`
+      #
+      # @!method fast_forward
+      #   Send the {FASTFORWARD} command to the item
+      #   @return [PlayerItem] `self`
+      #
+      # @!method fast_forward!
+      #   Send the {FASTFORWARD} command to the item, even when
+      #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
+      #   @return [PlayerItem] `self`
+      #
+      # @!method next
+      #   Send the {NEXT} command to the item
+      #   @return [PlayerItem] `self`
+      #
+      # @!method previous
+      #   Send the {PREVIOUS} command to the item
+      #   @return [PlayerItem] `self`
+      #
       class PlayerItem < GenericItem
-        # @!method play?
-        #   Check if the item state == {PLAY}
-        #   @return [true,false]
-
-        # @!method paused?
-        #   Check if the item state == {PAUSE}
-        #   @return [true,false]
-
-        # @!method rewinding?
-        #   Check if the item state == {REWIND}
-        #   @return [true,false]
-
-        # @!method fast_forwarding?
-        #   Check if the item state == {FASTFORWARD}
-        #   @return [true,false]
-
-        # @!method play
-        #   Send the {PLAY} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method play!
-        #   Send the {PLAY} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [PlayerItem] `self`
-
-        # @!method pause
-        #   Send the {PAUSE} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method pause!
-        #   Send the {PAUSE} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [PlayerItem] `self`
-
-        # @!method rewind
-        #   Send the {REWIND} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method rewind!
-        #   Send the {REWIND} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [PlayerItem] `self`
-
-        # @!method fast_forward
-        #   Send the {FASTFORWARD} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method fast_forward!
-        #   Send the {FASTFORWARD} command to the item, even when
-        #     {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
-        #   @return [PlayerItem] `self`
-
-        # @!method next
-        #   Send the {NEXT} command to the item
-        #   @return [PlayerItem] `self`
-
-        # @!method previous
-        #   Send the {PREVIOUS} command to the item
-        #   @return [PlayerItem] `self`
       end
     end
   end

--- a/lib/openhab/core/items/rollershutter_item.rb
+++ b/lib/openhab/core/items/rollershutter_item.rb
@@ -16,6 +16,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [PercentType, UpDownType, nil]
       #
+      # @!attribute [r] was
+      #   @return [PercentType, UpDownType, nil]
+      #   @since openHAB 5.0
+      #
       # @example Roll up all Rollershutters in a group
       #   Shutters.up
       #
@@ -36,6 +40,14 @@ module OpenHAB
         # @!method down?
         #   Check if the item state == {DOWN}
         #   @return [true,false]
+
+        # @!method was_up?
+        #   Check if {#was} is {UP}
+        #   @return [true, false]
+
+        # @!method was_down?
+        #   Check if {#was} is {DOWN}
+        #   @return [true, false]
 
         # @!method up
         #   Send the {UP} command to the item

--- a/lib/openhab/core/items/string_item.rb
+++ b/lib/openhab/core/items/string_item.rb
@@ -14,6 +14,10 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [StringType, nil]
       #
+      # @!attribute [r] was
+      #   @return [StringType, nil]
+      #   @since openHAB 5.0
+      #
       # @example
       #   # StringOne has a current state of "Hello"
       #   StringOne << StringOne + " World!"

--- a/lib/openhab/core/items/switch_item.rb
+++ b/lib/openhab/core/items/switch_item.rb
@@ -14,6 +14,9 @@ module OpenHAB
       # @!attribute [r] state
       #   @return [OnOffType, nil]
       #
+      # @!attribute [r] was
+      #   @return [OnOffType, nil]
+      #   @since openHAB 5.0
       #
       # @example Turn on all switches in a `Group:Switch` called Switches
       #   Switches.on
@@ -76,6 +79,14 @@ module OpenHAB
         # @!method off!
         #   Send the {OFF} command to the item, even when {OpenHAB::DSL.ensure_states! ensure_states!} is in effect.
         #   @return [SwitchItem] `self`
+
+        # @!method was_on?
+        #   Check if {#was} is (implicitly convertible to) {ON}
+        #   @return [true, false]
+
+        # @!method was_off?
+        #   Check if {#was} is (implicitly convertible to) {OFF}
+        #   @return [true, false]
       end
     end
   end

--- a/spec/openhab/core/items/item_spec.rb
+++ b/spec/openhab/core/items/item_spec.rb
@@ -200,6 +200,169 @@ RSpec.describe OpenHAB::Core::Items::Item do
     end
   end
 
+  describe "#was", if: OpenHAB::Core.version >= OpenHAB::Core::V5_0 do
+    it "returns nil if the item had never changed" do
+      expect(LightSwitch.was).to be_nil
+    end
+
+    it "returns the previous state" do
+      LightSwitch.update(ON)
+      LightSwitch.update(OFF)
+      expect(LightSwitch.was).to eql ON
+      expect(LightSwitch.was).to be_on
+      LightSwitch.update(ON)
+      expect(LightSwitch.was).to eql OFF
+      expect(LightSwitch.was).to be_off
+    end
+
+    it "returns nil if the item was NULL or UNDEF" do
+      LightSwitch.update(UNDEF)
+      LightSwitch.update(ON)
+      expect(LightSwitch.was).to be_nil
+      LightSwitch.update(NULL)
+      LightSwitch.update(ON)
+      expect(LightSwitch.was).to be_nil
+    end
+  end
+
+  describe "#was?", if: OpenHAB::Core.version >= OpenHAB::Core::V5_0 do
+    it "works" do
+      expect(LightSwitch.was?).to be false
+      LightSwitch.update(NULL)
+      expect(LightSwitch.was?).to be false
+      LightSwitch.update(ON)
+      expect(LightSwitch.was?).to be false
+      LightSwitch.update(UNDEF)
+      expect(LightSwitch.was?).to be true
+      LightSwitch.update(OFF)
+      expect(LightSwitch.was?).to be false
+      LightSwitch.update(ON)
+      expect(LightSwitch.was?).to be true
+    end
+  end
+
+  context "with was_*? predicates", if: OpenHAB::Core.version >= OpenHAB::Core::V5_0 do
+    describe "#was_undef?" do
+      it "works" do
+        LightSwitch.update(UNDEF)
+        LightSwitch.update(ON)
+        expect(LightSwitch.was_undef?).to be true
+        LightSwitch.update(OFF)
+        expect(LightSwitch.was_undef?).to be false
+      end
+    end
+
+    describe "#was_null?" do
+      it "works" do
+        LightSwitch.update(NULL)
+        LightSwitch.update(ON)
+        expect(LightSwitch.was_null?).to be true
+        LightSwitch.update(OFF)
+        expect(LightSwitch.was_null?).to be false
+      end
+    end
+
+    describe "#was_on?" do
+      it "works" do
+        LightSwitch.update(ON)
+        LightSwitch.update(OFF)
+        expect(LightSwitch.was_on?).to be true
+        LightSwitch.update(ON)
+        expect(LightSwitch.was_on?).to be false
+      end
+    end
+
+    describe "#was_off?" do
+      it "works" do
+        LightSwitch.update(OFF)
+        LightSwitch.update(ON)
+        expect(LightSwitch.was_off?).to be true
+        LightSwitch.update(OFF)
+        expect(LightSwitch.was_off?).to be false
+      end
+    end
+
+    describe "#was_up?" do
+      it "works" do
+        items.build { rollershutter_item Shutter, state: UP }
+        Shutter.update(DOWN)
+        expect(Shutter.was_up?).to be true
+        Shutter.update(UP)
+        expect(Shutter.was_up?).to be false
+      end
+    end
+
+    describe "#was_down?" do
+      it "works" do
+        items.build { rollershutter_item Shutter, state: DOWN }
+        Shutter.update(UP)
+        expect(Shutter.was_down?).to be true
+        Shutter.update(DOWN)
+        expect(Shutter.was_down?).to be false
+      end
+    end
+
+    describe "#was_open?" do
+      it "works" do
+        items.build { contact_item Door, state: OPEN }
+        Door.update(CLOSED)
+        expect(Door.was_open?).to be true
+        Door.update(OPEN)
+        expect(Door.was_open?).to be false
+      end
+    end
+
+    describe "#was_closed?" do
+      it "works" do
+        items.build { contact_item Door, state: CLOSED }
+        Door.update(OPEN)
+        expect(Door.was_closed?).to be true
+        Door.update(CLOSED)
+        expect(Door.was_closed?).to be false
+      end
+    end
+
+    describe "#was_playing?" do
+      it "works" do
+        items.build { player_item Player, state: PLAY }
+        Player.update(PAUSE)
+        expect(Player.was_playing?).to be true
+        Player.update(PLAY)
+        expect(Player.was_playing?).to be false
+      end
+    end
+
+    describe "#was_paused?" do
+      it "works" do
+        items.build { player_item Player, state: PAUSE }
+        Player.update(PLAY)
+        expect(Player.was_paused?).to be true
+        Player.update(PAUSE)
+        expect(Player.was_paused?).to be false
+      end
+    end
+
+    describe "#was_rewinding?" do
+      it "works" do
+        items.build { player_item Player, state: REWIND }
+        Player.update(PLAY)
+        expect(Player.was_rewinding?).to be true
+        Player.update(REWIND)
+        expect(Player.was_rewinding?).to be false
+      end
+    end
+
+    describe "#was_fast_forwarding?" do
+      it "works" do
+        items.build { player_item Player, state: FASTFORWARD }
+        Player.update(PLAY)
+        expect(Player.was_fast_forwarding?).to be true
+        Player.update(FASTFORWARD)
+        expect(Player.was_fast_forwarding?).to be false
+      end
+    end
+  end
+
   describe "#formatted_state" do
     it "just returns the state if it has no format" do
       items.build { number_item MyTemp, state: 5.556 }


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/4351

YARD doesn't seem to pick up # @!method xxx inside an empty class.

```ruby
class PlayerItem < GenericItem
  # @!method play
end
```
`#play` won't be picked up.

see it here (it's not there): 
https://openhab.github.io/openhab-jruby/5.37/OpenHAB/Core/Items/PlayerItem.html (missing `play?`, `play`, etc)
https://openhab.github.io/openhab-jruby/5.37/OpenHAB/Core/Items/ContactItem.html (missing `open?`, `closed?`)

If I added one dummy method even with `@!visibility private`, yard would then pick it up.

Moving them up into the class preamble is the solution for now for empty classes unless YARD fixed this.

This affects `PlayerItem`, `ContactItem`

Reported: https://github.com/lsegal/yard/issues/1613
