### PR TITLE
Add a space between semantic name and its parent in #inspect

### DIFF
--- a/lib/openhab/core/items/semantics/semantic_tag.rb
+++ b/lib/openhab/core/items/semantics/semantic_tag.rb
@@ -86,7 +86,7 @@ module OpenHAB
 
           # @return [String]
           def inspect
-            parent = "(#{parent_uid})" unless parent_uid.empty?
+            parent = " (#{parent_uid})" unless parent_uid.empty?
             "#<OpenHAB::Core::Items::Semantics::#{name}#{parent} " \
               "label=#{label.inspect} " \
               "description=#{description.inspect} " \


### PR DESCRIPTION
Change from 
```
#<OpenHAB::Core::Items::Semantics::Thermometer(Equipment_Sensor) label="" description="" synonyms=[""]>
```

to:

```
#<OpenHAB::Core::Items::Semantics::Thermometer (Equipment_Sensor) label="" description="" synonyms=[""]>
```