### PR TITLE
Fix QuantityType#eql? raising exception on incompatible QuantityType unit

### DIFF
--- a/lib/openhab/core/types/quantity_type.rb
+++ b/lib/openhab/core/types/quantity_type.rb
@@ -117,6 +117,19 @@ module OpenHAB
         alias_method :|, :to_invertible_unit
 
         #
+        # Check equality without unit inversion
+        #
+        # @return [true,false] if the same value is represented, without unit inversion
+        #
+        def eql?(other)
+          return false unless other.instance_of?(self.class)
+          # compare_to in OH5 will throw an IAE if the units are not compatible
+          return false unless unit.compatible?(other.unit)
+
+          super
+        end
+
+        #
         # Comparison
         #
         # Comparisons against Numeric and DecimalType are allowed only within a

--- a/spec/openhab/core/types/quantity_type_spec.rb
+++ b/spec/openhab/core/types/quantity_type_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe OpenHAB::Core::Types::QuantityType do
     expect((0 | "W")..(10 | "W")).to cover(10 | "W")
   end
 
+  describe "#eql?" do
+    it "returns false for invertible units" do
+      expect(1 | "W").not_to eql(1 | "/W")
+    end
+  end
+
   describe "comparisons" do
     let(:ten_c) { QuantityType.new("10 °C") }
     let(:five_c) { QuantityType.new("5 °C") }

--- a/spec/openhab/dsl_spec.rb
+++ b/spec/openhab/dsl_spec.rb
@@ -483,8 +483,9 @@ RSpec.describe OpenHAB::DSL do
         expect(2 * w).to eql 10 | "W"
         expect((2 * kw).to_i).to eq 10_000
         expect(2 * w == 10).to be true
-        expect(5 / w).to eql 1 | "W"
-        expect((2 * w / 2)).to eql w
+        expect(5 / w).to eql 1 | "/W"
+        expect(2 * w / 2).to eql w
+        expect(2 * w / 2).not_to eql(kw)
       end
     end
 


### PR DESCRIPTION
There was a bug in our spec which core was happily allowing:

`(1 | "1/W").compare_to(1 | "W")` used to return `0`.

openHAB 5.0 now throws an exception when comparing invertible unit. 
Relevant [PR](https://github.com/openhab/openhab-core/pull/4571)



