### PR TITLE
Support `ItemStateUpdatedEvent#last_state_update` and `ItemStateChangedEvent#last_state_change`

### DIFF
--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -21,6 +21,21 @@ module OpenHAB
       @version ||= Gem::Version.new(VERSION).release.freeze
     end
 
+    #
+    # Returns the full version of openHAB
+    #
+    # The {version} method returns the release version, stripping off any
+    # additional qualifiers such as M1, or snapshots.
+    # This method returns the full version string, including the qualifiers.
+    #
+    # @return [Gem::Version] Returns the full version of openHAB
+    #
+    # @!visibility private
+    #
+    def self.full_version
+      @full_version ||= Gem::Version.new(VERSION).freeze
+    end
+
     raise "`openhab-scripting` requires openHAB >= 4.1.0" unless version >= V4_1
 
     # @return [Integer] Number of seconds to wait between checks for automation manager

--- a/lib/openhab/core/events/item_state_changed_event.rb
+++ b/lib/openhab/core/events/item_state_changed_event.rb
@@ -13,6 +13,14 @@ module OpenHAB
       class ItemStateChangedEvent < ItemEvent
         include ItemState
 
+        # @!attribute [r] last_state_update
+        #   @return [ZonedDateTime] the time the previous state update occurred
+        #   @since openHAB 5.0
+
+        # @!attribute [r] last_state_change
+        #   @return [ZonedDateTime] the time the previous state change occurred
+        #   @since openHAB 5.0
+
         # @!method was_undef?
         #   Check if {#was} is {UNDEF}
         #   @return [true, false]
@@ -74,6 +82,9 @@ module OpenHAB
         def inspect
           s = "#<OpenHAB::Core::Events::ItemStateChangedEvent item=#{item_name} " \
               "state=#{item_state.inspect} was=#{old_item_state.inspect}"
+          # @deprecated OH4.3 remove respond_to? checks in the next two lines when dropping OH 4.3
+          s += " last_state_update=#{last_state_update}" if respond_to?(:last_state_update) && last_state_update
+          s += " last_state_change=#{last_state_change}" if respond_to?(:last_state_change) && last_state_change
           s += " source=#{source.inspect}" if source
           "#{s}>"
         end

--- a/lib/openhab/core/events/item_state_updated_event.rb
+++ b/lib/openhab/core/events/item_state_updated_event.rb
@@ -14,6 +14,19 @@ module OpenHAB
       #
       class ItemStateUpdatedEvent < ItemEvent
         include ItemState
+
+        # @!attribute [r] last_state_update
+        #   @return [ZonedDateTime] the time the previous state update occurred
+        #   @since openHAB 5.0
+
+        # @return [String]
+        def inspect
+          s = "#<OpenHAB::Core::Events::ItemStateUpdatedEvent item=#{item_name} state=#{item_state.inspect}"
+          # @deprecated OH4.3 remove respond_to? check when dropping OH 4.3
+          s += " last_state_update=#{last_state_update}" if respond_to?(:last_state_update) && last_state_update
+          s += " source=#{source.inspect}" if source
+          "#{s}>"
+        end
       end
     end
   end

--- a/spec/openhab/core/events/item_state_changed_event_spec.rb
+++ b/spec/openhab/core/events/item_state_changed_event_spec.rb
@@ -2,12 +2,18 @@
 
 RSpec.describe OpenHAB::Core::Events::ItemStateChangedEvent do
   it "is inspectable" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event("item", NULL, ON)
+    # @deprecated OH4.3 remove args and pass 5 arguments directly when dropping oh 4.3
+    args = ["item", NULL, ON]
+    args += [nil, nil] if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event(*args)
     expect(event.inspect).to eql "#<OpenHAB::Core::Events::ItemStateChangedEvent item=item state=NULL was=ON>"
   end
 
   it "has proper predicates for an ON => NULL event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event("item", NULL, ON)
+    # @deprecated OH4.3 remove args and pass 5 arguments directly when dropping oh 4.3
+    args = ["item", NULL, ON]
+    args += [nil, nil] if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event(*args)
 
     expect(event).to be_null
     expect(event).not_to be_undef
@@ -20,7 +26,10 @@ RSpec.describe OpenHAB::Core::Events::ItemStateChangedEvent do
   end
 
   it "has proper predicates for an ON => UNDEF event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event("item", UNDEF, ON)
+    # @deprecated OH4.3 remove args and pass 5 arguments directly when dropping oh 4.3
+    args = ["item", UNDEF, ON]
+    args += [nil, nil] if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event(*args)
 
     expect(event).not_to be_null
     expect(event).to be_undef
@@ -33,7 +42,10 @@ RSpec.describe OpenHAB::Core::Events::ItemStateChangedEvent do
   end
 
   it "has proper predicates for a NULL => ON event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event("item", ON, NULL)
+    # @deprecated OH4.3 remove args and pass 5 arguments directly when dropping oh 4.3
+    args = ["item", ON, NULL]
+    args += [nil, nil] if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event(*args)
 
     expect(event).not_to be_null
     expect(event).not_to be_undef
@@ -46,7 +58,10 @@ RSpec.describe OpenHAB::Core::Events::ItemStateChangedEvent do
   end
 
   it "has proper predicates for an UNDEF => ON event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event("item", ON, UNDEF)
+    # @deprecated OH4.3 remove args and pass 5 arguments directly when dropping oh 4.3
+    args = ["item", ON, UNDEF]
+    args += [nil, nil] if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_changed_event(*args)
 
     expect(event).not_to be_null
     expect(event).not_to be_undef

--- a/spec/openhab/core/events/item_state_updated_event_spec.rb
+++ b/spec/openhab/core/events/item_state_updated_event_spec.rb
@@ -5,14 +5,18 @@ RSpec.describe OpenHAB::Core::Events::ItemStateUpdatedEvent do
     event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", NULL, nil)
     expect(event.inspect).to eql "#<OpenHAB::Core::Events::ItemStateUpdatedEvent item=item state=NULL>"
 
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", NULL, "source")
+    # @deprecated OH4.3 remove args and pass 4 arguments directly when dropping oh 4.3
+    args = ["item", NULL]
+    args << nil if OpenHAB::Core.full_version > Gem::Version.new("5.0.0.M1")
+    args << "source"
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event(*args)
     expect(event.inspect).to eql(
       '#<OpenHAB::Core::Events::ItemStateUpdatedEvent item=item state=NULL source="source">'
     )
   end
 
   it "has proper predicates for a NULL event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", NULL)
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", NULL, nil)
 
     expect(event).to be_null
     expect(event).not_to be_undef
@@ -21,7 +25,7 @@ RSpec.describe OpenHAB::Core::Events::ItemStateUpdatedEvent do
   end
 
   it "has proper predicates for an UNDEF event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", UNDEF)
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", UNDEF, nil)
 
     expect(event).not_to be_null
     expect(event).to be_undef
@@ -30,7 +34,7 @@ RSpec.describe OpenHAB::Core::Events::ItemStateUpdatedEvent do
   end
 
   it "has proper predicates for an ON event" do
-    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", ON)
+    event = OpenHAB::Core::Events::ItemEventFactory.create_state_updated_event("item", ON, nil)
 
     expect(event).not_to be_null
     expect(event).not_to be_undef


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/4606

This affects the event's #inspect method, so marking this as ehancement, not just documentation changes