### PR TITLE
Fix problem in getting the provider for entities of ManagedProvider

### DIFF
--- a/lib/openhab/core/registry.rb
+++ b/lib/openhab/core/registry.rb
@@ -19,21 +19,8 @@ module OpenHAB
       #
       def provider_for(key)
         elementReadLock.lock
-        if key.is_a?(org.openhab.core.common.registry.Identifiable)
-          return unless (provider = elementToProvider[key])
-
-          # The HashMap lookup above uses java's hashCode() which has been overridden
-          # by GenericItem and ThingImpl to return object's uid, e.g. item's name, thing uid
-          # so it will return a provider even for an unmanaged object having the same uid
-          # as an existing managed object.
-
-          # So take an extra step to verify that the provider really holds the given instance.
-          # by using equal? to compare the object's identity.
-          # Only ManagedProviders have a #get method to look up the object by uid.
-          provider if !provider.is_a?(ManagedProvider) || provider.get(key.uid).equal?(key)
-        elsif (element = identifierToElement[key])
-          elementToProvider[element]
-        end
+        element = key.is_a?(org.openhab.core.common.registry.Identifiable) ? key : identifierToElement[key]
+        elementToProvider[element] if element
       ensure
         elementReadLock.unlock
       end

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -180,7 +180,6 @@ module OpenHAB
             provider.all.each do |link|
               provider.remove(link.uid) if link.item_name == item.name && !channel_uids.include?(link.linked_uid)
             end
-
             item
           end
         end
@@ -698,8 +697,8 @@ module OpenHAB
         # @!visibility private
         def build
           item = create_item
-          item.label = label
-          item.category = icon.to_s if icon
+          item.set_label(label) # Don't use item#label= because it triggers a provider.update
+          item.set_category(icon.to_s) if icon # ditto here
           groups.each do |group|
             group = group.name if group.respond_to?(:name)
             item.add_group_name(group.to_s)

--- a/lib/openhab/rspec/mocks/persistence_service.rb
+++ b/lib/openhab/rspec/mocks/persistence_service.rb
@@ -79,7 +79,7 @@ module OpenHAB
           item_history.insert(insert_index, new_item)
         end
 
-        def remove(filter)
+        def remove(filter, _alias = nil)
           query_internal(filter) do |item_history, index|
             historic_item = item_history.delete_at(index)
             @data.delete(historic_item.name) if item_history.empty?
@@ -87,7 +87,7 @@ module OpenHAB
           true
         end
 
-        def query(filter)
+        def query(filter, _alias = nil)
           result = []
 
           query_internal(filter) do |item_history, index|

--- a/spec/openhab/core/items/registry_spec.rb
+++ b/spec/openhab/core/items/registry_spec.rb
@@ -29,10 +29,11 @@ RSpec.describe OpenHAB::Core::Items::Registry do
       expect(SwitchTwo.provider).to be_a OpenHAB::Core::Items::Provider
     end
 
-    it "returns nil for items that aren't registered" do
-      expect(SwitchTwo.provider).not_to be_nil
-      unmanaged_item = OpenHAB::DSL::Items::ItemBuilder.item_factory.create_item("Switch", "SwitchTwo")
-      expect(unmanaged_item.provider).to be_nil
+    it "works on managed providers" do
+      items.build(:persistent) { switch_item "ManagedItem1" }
+      expect(ManagedItem1.provider).to be_a org.openhab.core.items.ManagedItemProvider
+    ensure
+      items.remove("ManagedItem1")
     end
   end
 end


### PR DESCRIPTION
ManagedProvider's Item.provider returned nil

This stopped us from notifying the ManagedProvider of any changes.

Using object (reference) comparison doesn't work for AbstractManagedProvider (JSON db stuff) nor for GenericItemProvider because they don't keep a reference to the objects. They would recreate them on the fly every time we call `get`, so the object returned cannot be compared by reference.

The original reason for comparing by reference was to check whether an item was updated or remained the same, especially within the spec.

This PR changed the verification approach by checking to see if provider.update was ever called. This achieved the same goal of ensuring that unchanged items during build do not trigger unnecessary update notifications to listeners.

