### PR TITLE
Add "openhab" dependency to gemspec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
       - uses: rubygems/release-gem@v1
         with:
           await-release: false
+      - uses: rubygems/release-gem@v1
+        env:
+          OPENHAB_SCRIPTING_RELEASE_GEM_NAME: rspec-openhab-scripting
+        with:
+          await-release: false
       - name: Create Github Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,10 @@ Bundler/GemFilename:
 FactoryBot:
   Enabled: false
 
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - rspec-openhab-scripting.gemspec
+
 Layout/LineLength:
   AllowedPatterns:
     - "# @!method" # Some YARD tags can't be broken up onto multiple lines

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,12 @@
 
 source "https://rubygems.org"
 
-gemspec
-
 plugin "bundler-multilock", "1.3.1"
 return unless Plugin.installed?("bundler-multilock")
 
 Plugin.send(:load_plugin, "bundler-multilock")
+
+gemspec name: "rspec-openhab-scripting"
 
 lockfile active: RUBY_VERSION >= "2.7" do
   # these gems are not compatible with Ruby 2.6/JRuby 9.3, but we don't need them to actually

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    openhab-scripting (5.35.1)
+    rspec-openhab-scripting (5.35.1)
       bundler (~> 2.2)
       marcel (~> 1.0)
       method_source (~> 1.0)
@@ -193,11 +193,11 @@ DEPENDENCIES
   httparty (~> 0.20)
   irb (~> 1.6)
   nokogiri (~> 1.15)
-  openhab-scripting!
   persistent_httparty (~> 0.1)
   process_exists (~> 0.2)
   rake (~> 13.0)
   rspec (~> 3.11)
+  rspec-openhab-scripting!
   rubocop-inst (~> 1.0)
   rubocop-rake (~> 0.6)
   rubocop-rspec (~> 2.11)

--- a/Gemfile.ruby-2.6.lock
+++ b/Gemfile.ruby-2.6.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    openhab-scripting (5.35.1)
+    rspec-openhab-scripting (5.35.1)
       bundler (~> 2.2)
       marcel (~> 1.0)
       method_source (~> 1.0)
@@ -131,11 +131,11 @@ DEPENDENCIES
   gem-release (~> 2.2)
   httparty (~> 0.20)
   nokogiri (~> 1.13.0)
-  openhab-scripting!
   persistent_httparty (~> 0.1)
   process_exists (~> 0.2)
   rake (~> 13.0)
   rspec (~> 3.11)
+  rspec-openhab-scripting!
   thin (~> 1.8.1)
   timecop (~> 0.9)
   tty-command (~> 0.10)

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require "rake/clean"
 require "rake/packagetask"
 
-require "bundler/gem_tasks"
+CLOBBER.include "pkg"
+require "bundler/gem_helper"
+Bundler::GemHelper.install_tasks(name: ENV["OPENHAB_SCRIPTING_RELEASE_GEM_NAME"] || "openhab-scripting")
 
 require "English"
 require "time"

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/openhab/dsl/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "openhab-scripting"
+  spec.name          = $openhab_scripting_gem_name || "openhab-scripting" # rubocop:disable Style/GlobalVars
   spec.version       = OpenHAB::DSL::VERSION
   spec.licenses      = ["EPL-2.0"]
   spec.authors       = ["Brian O'Connell", "Cody Cutrer", "Jimmy Tanagra"]
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => "https://github.com/openhab/openhab-jruby",
-    "documentation_uri" => "https://openhab.github.io/openhab-jruby/",
     "changelog_uri" => "https://openhab.github.io/openhab-jruby/file.CHANGELOG.html",
     "rubygems_mfa_required" => "true"
   }
@@ -24,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bundler", "~> 2.2"
   spec.add_runtime_dependency "marcel", "~> 1.0"
   spec.add_runtime_dependency "method_source", "~> 1.0"
+  spec.add_runtime_dependency "openhab", ">= 3.4.0", "< 5.1" unless $skip_openhab_dependency # rubocop:disable Style/GlobalVars
   spec.add_runtime_dependency "ruby2_keywords", "~> 0.0"
 
   spec.add_development_dependency "cucumber", "~> 8.0"

--- a/openhab.gemspec
+++ b/openhab.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "openhab"
+  spec.version = "0.a"
+  spec.licenses = ["EPL-2.0"]
+  spec.authors = ["Cody Cutrer"]
+  spec.email = ["cody@cutrer.us"]
+
+  spec.summary = "Dummy gem for openHAB to satisfy gem dependencies"
+  spec.description = <<~TEXT
+    This is a dummy gem for openHAB to satisfy gem dependencies.
+    It does not contain any functionality, and should not actually be installed.
+  TEXT
+  spec.homepage = "https://openhab.org/"
+
+  spec.required_ruby_version = Gem::Requirement.new("<= 0.a") # rubocop:disable Gemspec/RequiredRubyVersion
+
+  spec.metadata = {
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/openhab/openhab-jruby",
+    "documentation_uri" => "https://openhab.github.io/openhab-jruby/",
+    "rubygems_mfa_required" => "true"
+  }
+end

--- a/rspec-openhab-scripting.gemspec
+++ b/rspec-openhab-scripting.gemspec
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "bundler"
+
+# rubocop:disable Style/GlobalVars
+
+$skip_openhab_dependency = true
+$openhab_scripting_gem_name = "rspec-openhab-scripting"
+begin
+  Bundler.load_gemspec_uncached("openhab-scripting.gemspec")
+ensure
+  $skip_openhab_dependency = false
+  $openhab_scripting_gem_name = nil
+end
+
+# rubocop:enable Style/GlobalVars


### PR DESCRIPTION
So that we can require a specific version of openHAB -- which in reality allows us to drop older versions, without doing a major version change

In order to do this, I need a version of the gem without that dependency, so that development tasks can still work