### PR TITLE
remove ruby2_keywords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ PATH
       bundler (~> 2.2)
       marcel (~> 1.0)
       method_source (~> 1.0)
-      ruby2_keywords (~> 0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -175,7 +174,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     stringio (3.1.5)
     sys-uname (1.3.1)
       ffi (~> 1.1)

--- a/lib/openhab/core/entity_lookup.rb
+++ b/lib/openhab/core/entity_lookup.rb
@@ -121,7 +121,7 @@ module OpenHAB
       #
       # @return [Item, Things::Thing, nil]
       #
-      ruby2_keywords def method_missing(method, *args)
+      def method_missing(method, *args)
         return super unless args.empty? && !block_given?
 
         logger.trace { "method missing, performing openHAB Lookup for: #{method}" }

--- a/lib/openhab/core/items.rb
+++ b/lib/openhab/core/items.rb
@@ -64,35 +64,35 @@ module OpenHAB
               logger.trace { "Defining #{klass}/Enumerable##{command}/#{command}! for #{value}" }
 
               klass.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-                ruby2_keywords def #{command}(*args, &block)   # ruby2_keywords def on(*args, &block)
-                  command(#{value}, *args, &block)             #   command(ON, *args, &block)
-                end                                            # end
-                                                               #
-                ruby2_keywords def #{command}!(*args, &block)  # ruby2_keywords def on!(*args, &block)
-                  command!(#{value}, *args, &block)            #   command!(ON, *args, &block)
-                end                                            # end
+                def #{command}(...)       # def on(...)
+                  command(#{value}, ...)  #   command(ON, ...)
+                end                       # end
+                                          #
+                def #{command}!(...)      # def on!(...)
+                  command!(#{value}, ...) #   command!(ON, ...)
+                end                       # end
               RUBY
 
               Enumerable.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-                ruby2_keywords def #{command}(*args, &block)    # ruby2_keywords def on(*args, &block)
-                  each do |member|                              #   each do |member|
-                    member.#{command}(*args, &block)            #     member.on(*args, &block)
-                  end                                           #   end
-                end                                             # end
-                                                                #
-                ruby2_keywords def #{command}!(*args, &block)   # ruby2_keywords def on!(*args, &block)
-                  each do |member|                              #   each do |member|
-                    member.#{command}!(*args, &block)           #     member.on!(*args, &block)
-                  end                                           #   end
-                end                                             # end
+                def #{command}(...)         # def on(...)
+                  each do |member|          #   each do |member|
+                    member.#{command}(...)  #     member.on(...)
+                  end                       #   end
+                end                         # end
+                                            #
+                def #{command}!(...)        # def on!(...)
+                  each do |member|          #   each do |member|
+                    member.#{command}!(...) #     member.on!(...)
+                  end                       #   end
+                end                         # end
               RUBY
             else
               logger.trace { "Defining #{klass}/Enumerable##{command} for #{value}" }
 
               klass.class_eval <<~RUBY, __FILE__, __LINE__ + 1
-                ruby2_keywords def #{command}(*args, &block)  # ruby2_keywords def refresh(*args, &block)
-                  command!(#{value}, *args, &block)           #   command!(REFRESH, *args, &block)
-                end                                           # end
+                def #{command}(...)       # def refresh(...)
+                  command!(#{value}, ...) #   command!(REFRESH, ...)
+                end                       # end
               RUBY
 
               Enumerable.class_eval <<~RUBY, __FILE__, __LINE__ + 1

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -1056,7 +1056,7 @@ module OpenHAB
     # see OpenHAB::DSL::Rules::AutomationRule#execute!
     #
     # @!visibility private
-    ruby2_keywords def method_missing(method, *args)
+    def method_missing(method, *args)
       return super unless args.empty? && !block_given?
 
       if (context = Thread.current[:openhab_context]) && context.key?(method)

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 2.2"
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
-  spec.add_dependency "ruby2_keywords", "~> 0.0"
 
   spec.add_development_dependency "cucumber", "~> 8.0"
   spec.add_development_dependency "cuke_linter", "~> 1.2"


### PR DESCRIPTION
no longer necessary with Ruby 3.1 minimum version