### PR TITLE
Add RawType#bytesize

### DIFF
--- a/lib/openhab/core/items/image_item.rb
+++ b/lib/openhab/core/items/image_item.rb
@@ -41,7 +41,6 @@ module OpenHAB
         # @param [String] file location
         # @param [String] mime_type of image
         #
-        #
         def update_from_file(file, mime_type: nil)
           file_data = File.binread(file)
           mime_type ||= Marcel::MimeType.for(Pathname.new(file)) || Marcel::MimeType.for(file_data)
@@ -52,7 +51,6 @@ module OpenHAB
         # Update image from image at URL
         #
         # @param [String] uri location of image
-        #
         #
         def update_from_url(uri)
           logger.trace { "Downloading image from #{uri}" }
@@ -69,26 +67,12 @@ module OpenHAB
         # @param [String] mime_type of image
         # @param [Object] bytes image data
         #
-        #
         def update_from_bytes(bytes, mime_type: nil)
           mime_type ||= detect_mime_from_bytes(bytes:)
-          base_64_image = encode_image(mime_type:, bytes:)
-          update(base_64_image)
+          update(RawType.new(bytes.to_java_bytes, mime_type))
         end
 
         private
-
-        #
-        # Encode image information in the format required by openHAB
-        #
-        # @param [String] mime_type for image
-        # @param [Object] bytes image data
-        #
-        # @return [String] openHAB image format with image data Base64 encoded
-        #
-        def encode_image(mime_type:, bytes:)
-          "data:#{mime_type};base64,#{Base64.strict_encode64(bytes)}"
-        end
 
         #
         # Detect the mime type based on bytes

--- a/lib/openhab/core/types/raw_type.rb
+++ b/lib/openhab/core/types/raw_type.rb
@@ -10,14 +10,20 @@ module OpenHAB
       #
       # This type can be used for all binary data such as images, documents, sounds etc.
       #
-      class RawType # rubocop:disable Lint/EmptyClass
+      class RawType
         # @!parse include State
 
-        # @!method mime_type
+        # @attribute [r] mime_type
         #   @return [String]
 
-        # @!method bytes
-        #   @return [String]
+        # @attribute[r] bytes
+        #   @return [byte[]]
+
+        # @attribute [r] bytesize
+        # @return [Integer]
+        def bytesize
+          bytes.size
+        end
       end
     end
   end

--- a/spec/openhab/core/items/image_item_spec.rb
+++ b/spec/openhab/core/items/image_item_spec.rb
@@ -17,41 +17,39 @@ RSpec.describe OpenHAB::Core::Items::ImageItem do
     expect(item).not_to be_a_group_item
   end
 
-  # rubocop:disable Performance/StringBytesize
   it "provides access to underlying raw type" do
     item.update(image_base64)
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
 
   it "can be updated from a byte array with mime type" do
     item.update_from_bytes(File.binread(fixture("1x1.png")), mime_type: "image/png")
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
 
   it "can be updated from a byte array" do
     item.update_from_bytes(File.binread(fixture("1x1.png")))
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
 
   it "can be updated from a file with mime type" do
     item.update_from_file(fixture("1x1.png"), mime_type: "image/png")
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
 
   it "can be updated from a file" do
     item.update_from_file(fixture("1x1.png"))
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
 
   it "can be updated from a URL" do
     item.update_from_url("https://raw.githubusercontent.com/boc-tothefuture/openhab-jruby/main/features/assets/1x1.png")
     expect(item.state.mime_type).to eql "image/png"
-    expect(item.state.bytes.length).to be 95
+    expect(item.state.bytesize).to be 95
   end
-  # rubocop:enable Performance/StringBytesize
 end


### PR DESCRIPTION
to satisfy the Rubocop Performance/StringBytesize cop

also avoid an extraneous Base64 encode for an image, when we can directly create the RawType