### PR TITLE
move jar-dependencies to be an actual dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@
 
 source "https://rubygems.org"
 
-# see https://github.com/jruby/jruby/issues/8606
-# once we no longer support a JRuby < 9.4.12.0 (openHAB 5.0+), this can be removed
-# @deprecated OH 5.0
-gem "jar-dependencies", "0.4.1", platform: :jruby, require: false
-
 gemspec
 
 gem "debug", "~> 1.9", require: false, platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
     openhab-scripting (5.36.0)
       bundler (~> 2.2)
       irb (~> 1.15)
+      jar-dependencies (= 0.4.1)
       marcel (~> 1.0)
       method_source (~> 1.0)
 
@@ -206,7 +207,6 @@ DEPENDENCIES
   debug (~> 1.9)
   gem-release (~> 2.2)
   httparty (~> 0.20)
-  jar-dependencies (= 0.4.1)
   nokogiri (~> 1.15)
   openhab-scripting!
   persistent_httparty (~> 0.1)

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -23,6 +23,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler", "~> 2.2"
   spec.add_dependency "irb", "~> 1.15"
+  # see https://github.com/jruby/jruby/issues/8606
+  # once we no longer support a JRuby < 9.4.12.0 (openHAB 5.0+), this can be removed
+  # @deprecated OH 5.0
+  spec.add_dependency "jar-dependencies", "0.4.1"
+
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
 


### PR DESCRIPTION
so that openHAB gets the version that doesn't asplode