### PR TITLE
don't strip unknown links to preserve path replacements

### DIFF
--- a/lib/openhab/yard/markdown_helper.rb
+++ b/lib/openhab/yard/markdown_helper.rb
@@ -45,6 +45,9 @@ module OpenHAB
               if match
                 log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text#{match ? ":" : "."}\n" \
                          "\t#{match[1] ? "..." : ""}#{match[2].delete("\n")}#{match[3] ? "..." : ""}"
+                # Don't strip the link. This is so literals like {RUBY_ENGINE_VERSION} remain as they are,
+                # not stripped to "RUBY_ENGINE_VERSION"
+                next str
               end
             end
 


### PR DESCRIPTION
such as {RUBY_ENGINE_VERSION} etc. in the docs.

