### PR TITLE
Autoload builders (items, things, sitemaps, rules) and item metadata

### DIFF
--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -149,5 +149,6 @@ end
 require_relative "core/provider"
 
 Dir[File.expand_path("core/**/*.rb", __dir__)].each do |f|
-  require f
+  # metadata is autoloaded
+  require f unless f.include?("/metadata/")
 end

--- a/lib/openhab/core/items/generic_item.rb
+++ b/lib/openhab/core/items/generic_item.rb
@@ -231,7 +231,7 @@ module OpenHAB
         #     @return [void]
         def tags=(values)
           modify do
-            values = DSL::Items::ItemBuilder.normalize_tags(*values)
+            values = DSL::Items::Tags.normalize(*values)
             next if values.to_set == tags.to_set
 
             @modified = true

--- a/lib/openhab/core/items/metadata.rb
+++ b/lib/openhab/core/items/metadata.rb
@@ -5,6 +5,9 @@ module OpenHAB
     module Items
       # Contains classes wrapping interactions with item metadata.
       module Metadata
+        autoload :Provider, "openhab/core/items/metadata/provider"
+        autoload :NamespaceHash, "openhab/core/items/metadata/namespace_hash"
+        autoload :Hash, "openhab/core/items/metadata/hash"
       end
     end
   end

--- a/lib/openhab/core/items/metadata/namespace_hash.rb
+++ b/lib/openhab/core/items/metadata/namespace_hash.rb
@@ -2,6 +2,8 @@
 
 require "forwardable"
 
+require_relative "hash"
+
 module OpenHAB
   module Core
     module Items

--- a/lib/openhab/core/items/registry.rb
+++ b/lib/openhab/core/items/registry.rb
@@ -4,7 +4,6 @@ require "singleton"
 
 require "openhab/core/entity_lookup"
 require "openhab/core/lazy_array"
-require "openhab/dsl/items/builder"
 
 module OpenHAB
   module Core

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -10,7 +10,8 @@ require_relative "osgi"
 require_relative "core"
 
 Dir[File.expand_path("dsl/**/*.rb", __dir__)].each do |f|
-  require f
+  # some files are excluded because they're autoloaded
+  require f unless f.include?("/rules/") || f =~ %r{dsl/(items|sitemaps|things)/builder.rb$}
 end
 
 require_relative "core_ext"
@@ -27,6 +28,32 @@ module OpenHAB
   # inside of other classes, or include the module.
   #
   module DSL
+    module Items
+      autoload :Builder, "openhab/dsl/items/builder"
+      autoload :BaseBuilderDSL, "openhab/dsl/items/builder"
+      autoload :ItemBuilder, "openhab/dsl/items/builder"
+    end
+
+    module Things
+      autoload :Builder, "openhab/dsl/things/builder"
+    end
+
+    module Sitemaps
+      autoload :Builder, "openhab/dsl/sitemaps/builder"
+      autoload :LinkableWidgetBuilder, "openhab/dsl/sitemaps/builder"
+    end
+
+    module Rules
+      # sorted alphabetically
+      autoload :AutomationRule, "openhab/dsl/rules/automation_rule"
+      autoload :Builder, "openhab/dsl/rules/builder"
+      autoload :Guard, "openhab/dsl/rules/guard"
+      autoload :NameInference, "openhab/dsl/rules/name_inference"
+      autoload :Property, "openhab/dsl/rules/property"
+      autoload :RuleTriggers, "openhab/dsl/rules/rule_triggers"
+      autoload :Terse, "openhab/dsl/rules/terse"
+    end
+
     # include this before Core::Actions so that Core::Action's method_missing
     # takes priority
     include Core::EntityLookup

--- a/lib/openhab/dsl/items/builder.rb
+++ b/lib/openhab/dsl/items/builder.rb
@@ -278,27 +278,6 @@ module OpenHAB
           def item_factory
             @item_factory ||= OpenHAB::OSGi.service("org.openhab.core.items.ItemFactory")
           end
-
-          #
-          # Convert the given array to an array of strings.
-          # Convert Semantics classes to their simple name.
-          #
-          # @param [String,Symbol,Semantics::Tag] tags A list of strings, symbols, or Semantics classes
-          # @return [Array] An array of strings
-          #
-          # @example
-          #   tags = normalize_tags("tag1", Semantics::LivingRoom)
-          #
-          # @!visibility private
-          def normalize_tags(*tags)
-            tags.compact.map do |tag|
-              case tag
-              when String then tag
-              when Symbol, Semantics::SemanticTag then tag.to_s
-              else raise ArgumentError, "`#{tag}` must be a subclass of Semantics::Tag, a `Symbol`, or a `String`."
-              end
-            end
-          end
         end
 
         # @param dimension [Symbol, String, nil] The unit dimension for a {NumberItem} (see {ItemBuilder#dimension})
@@ -450,7 +429,7 @@ module OpenHAB
         def tag(*tags)
           return @tags if tags.empty?
 
-          @tags.concat(self.class.normalize_tags(*tags))
+          @tags.concat(Tags.normalize(*tags))
         end
         alias_method :tags, :tag
 

--- a/lib/openhab/dsl/items/tags.rb
+++ b/lib/openhab/dsl/items/tags.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module OpenHAB
+  module DSL
+    module Items
+      # A helper module for handling tags in OpenHAB DSL.
+      module Tags
+        module_function
+
+        #
+        # Convert the given array to an array of strings.
+        # Convert Semantics classes to their simple name.
+        #
+        # @param [String,Symbol,Semantics::Tag] tags A list of strings, symbols, or Semantics classes
+        # @return [Array] An array of strings
+        #
+        # @example
+        #   tags = normalize("tag1", Semantics::LivingRoom)
+        #
+        # @!visibility private
+        def normalize(*tags)
+          tags.compact.map do |tag|
+            case tag
+            when String then tag
+            when Symbol, Semantics::SemanticTag then tag.to_s
+            else raise ArgumentError,
+                       "`#{tag}` must be a subclass of Semantics::Tag, a `Symbol`, or a `String`."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -4,6 +4,7 @@ require "forwardable"
 
 require_relative "property"
 require_relative "guard"
+require_relative "triggers"
 require_relative "rule_triggers"
 require_relative "terse"
 

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -2212,7 +2212,7 @@ module OpenHAB
         # @return [void]
         def add_tag(tag)
           # have to normalize tags first
-          @tags = DSL::Items::ItemBuilder.normalize_tags(*tags)
+          @tags = DSL::Items::Tags.normalize(*tags)
           @tags << tag unless @tags.include?(tag)
         end
 
@@ -2240,7 +2240,7 @@ module OpenHAB
         # @return [true,false] true if it should be created, false otherwise
         #
         def create_rule?
-          @tags = DSL::Items::ItemBuilder.normalize_tags(*tags)
+          @tags = DSL::Items::Tags.normalize(*tags)
           return true if tags.intersect?(%w[Script Scene])
 
           if !triggers?

--- a/lib/openhab/dsl/rules/triggers.rb
+++ b/lib/openhab/dsl/rules/triggers.rb
@@ -10,3 +10,7 @@ module OpenHAB
     end
   end
 end
+
+Dir[File.expand_path("triggers/**/*.rb", __dir__)].each do |f|
+  require f
+end

--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -360,7 +360,7 @@ module OpenHAB
           @type = type
           @label = label
           @config = config&.transform_keys(&:to_s)
-          @default_tags = Items::ItemBuilder.normalize_tags(*Array.wrap(default_tags))
+          @default_tags = Items::Tags.normalize(*Array.wrap(default_tags))
           @properties = properties&.transform_keys(&:to_s)
           @description = description
           @accepted_item_type = accepted_item_type


### PR DESCRIPTION
To speed up the library's loading time, make some parts autoloaded (only loaded when needed)

- UI rules won't need to load the whole file-based `rule` creation support
- Most scripts don't need to load the items/things/sitemap builder
- item metadata handling

Resolve #418 

```
$ find lib -name 'builder.rb' -exec ls -lh {} \; | sort -h
-rw-rw-r-- 1 openhab openhab 17K Mar 25 01:00 lib/openhab/dsl/things/builder.rb
-rw-rw-r-- 1 openhab openhab 33K Apr  3 17:10 lib/openhab/dsl/items/builder.rb
-rw-rw-r-- 1 openhab openhab 59K Apr  3 16:26 lib/openhab/dsl/sitemaps/builder.rb

$ find lib -name 'builder.rb' -exec wc -l {} \; | sort -h
407 lib/openhab/dsl/things/builder.rb
864 lib/openhab/dsl/items/builder.rb
1488 lib/openhab/dsl/sitemaps/builder.rb
```

dsl/rules are only needed by file-based, so autoloading them would speed up UI rules

```
$ du -sh lib/openhab/dsl/rules
216K    lib/openhab/dsl/rules

$ find lib/openhab/dsl/rules -type f | xargs wc -l
    78 lib/openhab/dsl/rules/property.rb
    16 lib/openhab/dsl/rules/triggers.rb
    73 lib/openhab/dsl/rules/guard.rb
    98 lib/openhab/dsl/rules/rule_triggers.rb
   101 lib/openhab/dsl/rules/triggers/conditions/duration.rb
    66 lib/openhab/dsl/rules/triggers/conditions/generic.rb
    57 lib/openhab/dsl/rules/triggers/channel.rb
   270 lib/openhab/dsl/rules/triggers/watch/watch_handler.rb
    36 lib/openhab/dsl/rules/triggers/conditions.rb
    56 lib/openhab/dsl/rules/triggers/trigger.rb
   101 lib/openhab/dsl/rules/triggers/updated.rb
   242 lib/openhab/dsl/rules/triggers/cron/cron.rb
   142 lib/openhab/dsl/rules/triggers/changed.rb
    48 lib/openhab/dsl/rules/triggers/command.rb
    90 lib/openhab/dsl/rules/terse.rb
  2275 lib/openhab/dsl/rules/builder.rb
   171 lib/openhab/dsl/rules/name_inference.rb
   358 lib/openhab/dsl/rules/automation_rule.rb
  4278 total
```

The commits are split into two on purpose.

Benchmark results when loading 50 empty scripts sequentially. The unit is seconds.

```
Benchmark result
Type            System          User            Total           Real
Autoload on :   3.690000        196.700000      200.390000      (72.955197)
Autoload off:   4.590000        230.290000      234.880000      (77.681728)
```

Benchmark script:
For the purpose of benchmarking, the library was modified so that when `jrubyscripting.autoload` java system property is set to false, it would load everything without using autoload. This modification wasn't committed to the library as it's unnecessary when autoloading is enabled.

```ruby
# frozen_string_literal: true

require "securerandom"

gemfile do
  source "https://rubygems.org"
  gem "benchmark"
end

SCRIPT_ENGINE_MANAGER = OpenHAB::OSGi.service("org.openhab.core.automation.module.script.ScriptEngineManager")

logger.info "Script Engine Manager: #{SCRIPT_ENGINE_MANAGER}"

def script_loading(number, autoload)
  script_id = "benchmark-#{SecureRandom.uuid}"
  java.lang.System.set_property("jrubyscripting.autoload", autoload.to_s)
  container = SCRIPT_ENGINE_MANAGER.create_script_engine("rb", script_id)
  container.script_engine.then do |engine|
    engine.eval <<~RUBY
      logger.info "Script #{number} loaded with autoload: \#{AUTOLOAD}"
      # Add more user code here
    RUBY
  end
ensure
  SCRIPT_ENGINE_MANAGER.remove_engine(script_id)
  java.lang.System.clear_property("jrubyscripting.autoload")
end

iterations = 50
result = Benchmark.bm(7) do |x|
  x.report("Autoload on ") do
    iterations.times do |i|
      script_loading(i, true)
    end
  end

  x.report("Autoload off") do
    iterations.times do |i|
      script_loading(i, false)
    end
  end
end

message = [
  "Benchmark result",
  "Type\t\tSystem\t\tUser\t\tTotal\t\tReal"
] + result.map { |tms| tms.format("%n:\t%y\t%u\t%t\t%r") }
logger.info message.join("\n")
```