### PR TITLE
Support passing timer objects to other scripts via shared_cache

### DIFF
--- a/lib/openhab/core/timer.rb
+++ b/lib/openhab/core/timer.rb
@@ -45,6 +45,7 @@ module OpenHAB
       #
       # @!visibility private
       def initialize(time, id:, thread_locals:, block:)
+        @managed = true
         @time = time
         @id = id
         @thread_locals = thread_locals
@@ -95,7 +96,7 @@ module OpenHAB
       # @!visibility private
       def reschedule!(time = nil)
         Thread.current[:openhab_rescheduled_timer] = true if Thread.current[:openhab_rescheduled_timer] == self
-        DSL.timers.add(self)
+        DSL.timers.add(self) if managed?
         @timer.reschedule(new_execution_time(time || @time))
         self
       end
@@ -120,6 +121,79 @@ module OpenHAB
       # @!visibility private
       def cancel!
         @timer.cancel
+      end
+
+      #
+      # Returns the openHAB Timer object.
+      #
+      # This can be used to share the timer with other scripts via {OpenHAB::DSL.shared_cache shared_cache}.
+      # The other scripts can be other JRuby scripts or scripts written in a different language
+      # such as JSScripting, Python, etc. which can either be file-based or UI based scripts.
+      #
+      # Timers are normally managed by TimerManager, and are normally automatically cancelled
+      # when the script unloads/reloads.
+      #
+      # To disable this automatic timer cancellation at script unload, call {unmanage}.
+      #
+      # openHAB will cancel the timer stored in the {OpenHAB::DSL.shared_cache shared_cache}
+      # and remove the cache entry when all the scripts that _had accessed_ it have been unloaded.
+      #
+      # @return [org.openhab.core.automation.module.script.action.Timer]
+      #
+      # @see unmanage
+      #
+      # @example
+      #   # script1.rb:
+      #   timer = after(10.hours) { logger.warn "Timer created in script1.rb fired" }
+      #   shared_cache[:script1_timer] = timer.to_java
+      #
+      #   # script2.js: (JavaScript!)
+      #   rules.when().item("TestSwitch1").receivedCommand().then(event => {
+      #     cache.shared.get("script1_timer")?.cancel()
+      #   })
+      #
+      #   # or in Ruby script2.rb
+      #   received_command(TestSwitch2, command: ON) do
+      #     # This is an openHAB timer object, not a JRuby timer object
+      #     # the reschedule method expects a ZonedDateTime
+      #     shared_cache[:script1_timer]&.reschedule(3.seconds.from_now)
+      #   end
+      #
+      # @!visibility private
+      def to_java
+        @timer
+      end
+
+      #
+      # Removes the timer from the {TimerManager TimerManager}
+      #
+      # The effects of calling this method are:
+      # - The timer will no longer be automatically cancelled when the script unloads.
+      #   It will still execute as scheduled even if the script is unloaded/removed.
+      # - It can no longer be referenced by its `id`.
+      # - Subsequent calls to {OpenHAB::DSL.after after} with the same `id` will create a separate new timer.
+      # - Normal timer operations such as {reschedule}, {cancel}, etc. will still work.
+      #
+      # @return [org.openhab.core.automation.module.script.action.Timer] The openHAB Timer object
+      #
+      # @example
+      #   timer = after(10.hours) { logger.warn "Timer created in script1.rb fired" }
+      #   shared_cache[:script1_timer] = timer
+      #   # Don't cancel the timer when this script unloads,
+      #   # but openHAB will do it if all scripts that had referenced the shared cache are unloaded.
+      #   timer.unmanage
+      #
+      def unmanage
+        @managed = false
+        DSL.timers.delete(self)
+        @id = nil
+        @timer
+      end
+
+      # @return [true,false] True if the timer is managed by TimerManager, false otherwise.
+      #   A timer is managed by default, and becomes un-managed when {unmanage} is called.
+      def managed?
+        @managed
       end
 
       private

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -296,6 +296,19 @@ module OpenHAB
     # own instance of the timers object, so you don't need to worry about collisions among
     # different files.
     #
+    # ### Sharing Timers with other scripts
+    #
+    # When a timer is stored in the {shared_cache}, it will automatically be converted into
+    # an openHAB Timer object. It can then be used in other scripts or UI rules,
+    # written in JRuby or other supported languages.
+    #
+    # Timers are normally managed by TimerManager, and are normally automatically cancelled
+    # when the script unloads/reloads.
+    # To disable this automatic timer cancellation at script unload, call {Core::Timer#unmanage}.
+    #
+    # openHAB will cancel the timer stored in the {OpenHAB::DSL.shared_cache shared_cache}
+    # and remove the cache entry when all the scripts that _had accessed_ it have been unloaded.
+    #
     # @see timers
     # @see Rules::BuilderDSL#changed
     # @see Items::TimedCommand
@@ -376,6 +389,19 @@ module OpenHAB
     #       end
     #     end
     #   end
+    #
+    # @example Timers can be shared with other scripts
+    #   # script1.rb:
+    #   timer = after(10.hours) { logger.warn "Timer created in script1.rb fired" }
+    #   shared_cache[:script1_timer] = timer
+    #
+    #   # inside a different JRuby UI rule or script:
+    #   # This is an openHAB timer object, not a JRuby timer object
+    #   # the reschedule method expects a ZonedDateTime
+    #   shared_cache[:script1_timer]&.reschedule(10.seconds.from_now)
+    #
+    #   # inside another JS script:
+    #   cache.shared.get("script1_timer")?.cancel()
     #
     def after(duration, id: nil, reschedule: true, &block)
       raise ArgumentError, "Block is required" unless block

--- a/spec/openhab/core/value_cache_spec.rb
+++ b/spec/openhab/core/value_cache_spec.rb
@@ -148,4 +148,18 @@ RSpec.describe "OpenHAB::Core::ValueCache" do
       expect(shared_cache.values_at(:key1, :key2, :key3)).to eql [1, nil, 3]
     end
   end
+
+  context "when used to store a Timer" do
+    self.mock_timers = false
+    it "converts the timer to openHAB Timer" do
+      timer = after(1.seconds) { nil }
+      shared_cache[:timer] = timer
+      expect(shared_cache[:timer]).to be_a(org.openhab.core.automation.module.script.action.Timer)
+
+      shared_cache.compute_if_absent(:timer2) do
+        after(1.seconds) { nil }
+      end
+      expect(shared_cache[:timer2]).to be_a(org.openhab.core.automation.module.script.action.Timer)
+    end
+  end
 end


### PR DESCRIPTION
```ruby
timer = after(1.hour) { logger.info "Timer from Ruby" }
shared_cache[:mytimer] = timer
```

```ruby
# From another script/rule
shared_cache[:mytimer]&.reschedule(10.seconds.from_now)
```