### PR TITLE
shared_cache: prepend on the $sharedCache class, not its singleton class

### DIFF
--- a/lib/openhab/core/value_cache.rb
+++ b/lib/openhab/core/value_cache.rb
@@ -221,7 +221,7 @@ module OpenHAB
 
       # We use prepend here instead of overriding the methods inside ValueCache module/interface
       # because the methods are defined in the implementation class
-      $sharedCache.singleton_class.prepend(ValueConverter)
+      $sharedCache.class.prepend(ValueConverter)
     end
   end
 end


### PR DESCRIPTION
This avoids the warning

```
/openhab/conf/automation/ruby/.gem/9.4.12.0/gems/openhab-scripting-5.37.0/lib/openhab/core/value_cache.rb:224: warning: singleton on non-persistent Java type Java::OrgOpenhabCoreAutomationModuleScriptRulesupportInternal::CacheScriptExtension::TrackingValueCacheImpl (https://github.com/jruby/jruby/wiki/Persistence)
```