### PR TITLE
Re-add irb 1.15 to our dependency list

### DIFF
--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   RUBY_VERSION: 3.1.4
-  BUNDLE_LOCKFILE: active
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "jar-dependencies", "0.4.1", platform: :jruby, require: false
 gemspec
 
 gem "debug", "~> 1.9", require: false, platform: :mri
-gem "irb", "~> 1.15", require: false
 gem "nokogiri", "~> 1.15", require: false
 gem "rubocop-inst", "~> 1.0", require: false
 gem "rubocop-rake", "~> 0.6", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
   specs:
     openhab-scripting (5.38.2)
       bundler (~> 2.2)
+      irb (~> 1.15)
       marcel (~> 1.0)
       method_source (~> 1.0)
 
@@ -75,7 +76,7 @@ GEM
       multi_xml (>= 0.5.2)
     io-console (0.8.0)
     io-console (0.8.0-java)
-    irb (1.15.1)
+    irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
@@ -129,10 +130,10 @@ GEM
     rack (2.2.13)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.12.0)
+    rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
-    reline (0.6.0)
+    reline (0.6.1)
       io-console (~> 0.5)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -174,7 +175,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
-    stringio (3.1.5)
+    stringio (3.1.6)
     sys-uname (1.3.1)
       ffi (~> 1.1)
     thin (1.8.2)
@@ -205,7 +206,6 @@ DEPENDENCIES
   debug (~> 1.9)
   gem-release (~> 2.2)
   httparty (~> 0.20)
-  irb (~> 1.15)
   jar-dependencies (= 0.4.1)
   nokogiri (~> 1.15)
   openhab-scripting!
@@ -223,4 +223,4 @@ DEPENDENCIES
   yard!
 
 BUNDLED WITH
-   2.6.6
+   2.6.8

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency "bundler", "~> 2.2"
+  spec.add_dependency "irb", "~> 1.15"
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
 


### PR DESCRIPTION
I think the problem has been solved by jar-dependencies 0.5.5

My test:
```
bundle exec rake build
mkdir -p repo/gems
cp pkg/openhab-scripting-5.38.2.gem repo/gems
cd repo
gem generate_index

cat <<GEMFILE > ../tmp/Gemfile
source "https://rubygems.org"
source "file:///$(pwd)" do
  gem "openhab-scripting"
end
GEMFILE

cd ../tmp

#install jruby 9.4.5.0
rbenv install jruby-9.4.5.0
rbenv shell jruby-9.4.5.0
bundle install
```