### PR TITLE
Require irb ~> 1.14 to allow the version shipped with JRuby 10

### DIFF
--- a/lib/openhab/console/irb.rb
+++ b/lib/openhab/console/irb.rb
@@ -2,9 +2,9 @@
 
 require "openhab/console/stdio"
 
-gem "irb", "~> 1.15"
-
 require "irb"
+
+raise "IRB Version 1.14 or later is required." unless Gem::Version.new(IRB::VERSION) >= Gem::Version.new("1.14")
 
 module OpenHAB
   # @!visibility private


### PR DESCRIPTION
As #438 still proved to be difficult, this tackles it a different way.

JRuby 10 was just released, and with it, comes irb 1.14.3, which our curent irb code is happy with. Since the console is only available in openHAB 5, we could just reduce this version requirement to match JRuby10, and ship OH5 with JRuby10. That would also solve the irb issue.

