### PR TITLE
Don't require cucumber from rake task

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "cucumber"
 require "cucumber/rake/task"
 
 desc "Run Cucumber Features"


### PR DESCRIPTION
We only need the cucumber rake tasks, not all of cucumber, unless we're actually running that task