### PR TITLE
make sure string is non-frozen before mutating it

### DIFF
--- a/spec/openhab/core/items/persistence_spec.rb
+++ b/spec/openhab/core/items/persistence_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe OpenHAB::Core::Items::Persistence do
     updated?
     variance
   ].product(variants).each do |name, variant|
-    prefix = name.to_s
+    prefix = +name.to_s
     suffix = prefix.delete_suffix!("?") && "?"
     method = :"#{prefix}_#{variant}#{suffix}"
     next unless OpenHAB::Core::Items::Persistence.instance_methods.include?(method)


### PR DESCRIPTION
Symbol#to_s will be frozen in Ruby 3.5