### PR TITLE
fix various "instance vars on non-persistent Java type" warnings

### DIFF
--- a/lib/openhab/core/events/abstract_event.rb
+++ b/lib/openhab/core/events/abstract_event.rb
@@ -8,10 +8,30 @@ module OpenHAB
       # Add attachments event data.
       class AbstractEvent
         # @return [Object]
-        attr_accessor :attachment
+        attr_reader :attachment
 
         # @return [Hash]
-        attr_accessor :inputs
+        attr_reader :inputs
+
+        # @!visibility private
+        def attachment=(value)
+          # Disable "instance vars on non-persistent Java type"
+          original_verbose = $VERBOSE
+          $VERBOSE = nil
+          @attachment = value
+        ensure
+          $VERBOSE = original_verbose
+        end
+
+        # @!visibility private
+        def inputs=(value)
+          # Disable "instance vars on non-persistent Java type"
+          original_verbose = $VERBOSE
+          $VERBOSE = nil
+          @inputs = value
+        ensure
+          $VERBOSE = original_verbose
+        end
 
         # @!attribute [r] source
         # @return [String] The component that sent the event.
@@ -24,7 +44,12 @@ module OpenHAB
         #
         def payload
           require "json"
+          # Disable "instance vars on non-persistent Java type"
+          original_verbose = $VERBOSE
+          $VERBOSE = nil
           @payload ||= JSON.parse(get_payload, symbolize_names: true) unless get_payload.empty?
+        ensure
+          $VERBOSE = original_verbose
         end
 
         # @return [String]

--- a/lib/openhab/core/items/item.rb
+++ b/lib/openhab/core/items/item.rb
@@ -25,10 +25,10 @@ module OpenHAB
               OpenHAB::OSGi.service("org.openhab.core.io.rest.sse.internal.SseItemStatesEventBuilder")&.tap do |builder|
                 m = builder.class.java_class.get_declared_method("getDisplayState", Item, java.util.Locale)
                 m.accessible = true
-                builder.instance_variable_set(:@getDisplayState, m)
                 # Disable "singleton on non-persistent Java type"
                 original_verbose = $VERBOSE
                 $VERBOSE = nil
+                builder.instance_variable_set(:@getDisplayState, m)
                 def builder.get_display_state(item)
                   @getDisplayState.invoke(self, item, nil)
                 end

--- a/lib/openhab/core/things/profile_callback.rb
+++ b/lib/openhab/core/things/profile_callback.rb
@@ -8,16 +8,23 @@ module OpenHAB
       # and channels.
       #
       module ProfileCallback
+        class << self
+          # @!visibility private
+          def dummy_channel_item(accepted_item_type)
+            @dummy_channel_items[accepted_item_type]
+          end
+        end
+        @dummy_channel_items = Hash.new do |hash, key|
+          hash[key] = DSL::Items::ItemBuilder.item_factory.create_item(key, "")
+        end
+
         #
         # Forward the given command to the respective thing handler.
         #
         # @param [Command] command
         #
         def handle_command(command)
-          unless instance_variable_defined?(:@dummy_channel_item)
-            @dummy_channel_item = DSL::Items::ItemBuilder.item_factory.create_item(link.channel.accepted_item_type, "")
-          end
-          command = @dummy_channel_item.format_command(command) if @dummy_channel_item
+          command = ProfileCallback.dummy_channel_item(link.channel.accepted_item_type)&.format_command(command)
           super
         end
 

--- a/lib/openhab/core/value_cache.rb
+++ b/lib/openhab/core/value_cache.rb
@@ -175,7 +175,7 @@ module OpenHAB
 
       # @see https://docs.ruby-lang.org/en/master/Hash.html#method-i-to_proc Hash#to_proc
       def to_proc
-        @to_proc ||= ->(k) { self[k] }
+        ->(k) { self[k] }
       end
 
       # @see https://docs.ruby-lang.org/en/master/Hash.html#method-i-values_at Hash#values_at


### PR DESCRIPTION
 * just ignore them on events (we're not going to receive the object from java multiple times anyway)
 * cache the object externally for ProfileCallback
 * don't memoize ValueCache#to_proc