### PR TITLE
check versions.js into gh-pages /js directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,3 +84,25 @@ jobs:
     with:
       ref_name: v${{needs.release.outputs.NEW_VERSION}}
       ref_type: tag
+  publish_docs_versions:
+    needs: publish_main_docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Get versions.js from the main branch
+        run: |
+          git fetch origin main:main
+          git checkout main -- docs/js/versions.js
+          git reset docs/js/versions.js
+      - name: Update versions.js
+        run: |
+          mkdir -p js
+          mv docs/js/versions.js js/versions.js
+          git add js/versions.js
+          git config --local user.name 'github-actions[bot]'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "Update versions.js with new version v${{ env.NEW_VERSION }}"
+

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ DOC_FILES = %w[
   templates/default/layout/html/versions.erb
 ].freeze
 
-VERSIONS_JS = "templates/default/fulldoc/html/js/versions.js"
+VERSIONS_JS = "docs/js/versions.js"
 
 def file_sub(file, old, new)
   contents = File.read(file)

--- a/docs/js/versions.js
+++ b/docs/js/versions.js
@@ -1,3 +1,8 @@
+/**
+ * This script populates the archived versions dropdown in the documentation.
+ * Place this in the root /js/ directory outside of the versioned directories.
+ */
+
 function populateArchivedVersions() {
   const archivedVersions = [
     "5.0",

--- a/templates/default/layout/html/layout.erb
+++ b/templates/default/layout/html/layout.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <%= erb(:headers) %>
-    <script type="text/javascript" charset="utf-8" src="/openhab-jruby/main/js/versions.js"></script>
+    <script type="text/javascript" charset="utf-8" src="https://openhab.github.io/openhab-jruby/js/versions.js"></script>
     <meta property="og:description" name="description" content="<%= meta_description %>">
     <meta property="og:image" content="https://raw.githubusercontent.com/jruby/collateral/master/logos/PNGs/circle-fill/full-color/jruby-logo-circle-logo-fill-outline-medium.png">
     <meta property="og:image:alt" content="The JRuby logo">


### PR DESCRIPTION
- Put versions.js in docs/js/versions.js - yard doesn't include this in its output
- at the end of github yard workflow, put this file into gh-pages branch, in /js/versions.js
- Refer to this script in our pages with full url `https://openhab.github.io/openhab-jruby/js/versions.js`. By using this absolute url, local yard server will also pick it up (once it has been committed there)

This makes versions.js not be a part of each version's subdirectory in gh-pages. Instead we only have one global copy that's kept updated.