### PR TITLE
make archived version dropdown shorter in the older versions

### DIFF
--- a/5.0/css/sidebar.css
+++ b/5.0/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.1/css/sidebar.css
+++ b/5.1/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.10/css/sidebar.css
+++ b/5.10/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.11/css/sidebar.css
+++ b/5.11/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.12/css/sidebar.css
+++ b/5.12/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.15/css/sidebar.css
+++ b/5.15/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.17/css/sidebar.css
+++ b/5.17/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.18/css/sidebar.css
+++ b/5.18/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.19/css/sidebar.css
+++ b/5.19/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.2/css/sidebar.css
+++ b/5.2/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.20/css/sidebar.css
+++ b/5.20/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.21/css/sidebar.css
+++ b/5.21/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.22/css/sidebar.css
+++ b/5.22/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.23/css/sidebar.css
+++ b/5.23/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.24/css/sidebar.css
+++ b/5.24/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.25/css/sidebar.css
+++ b/5.25/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.26/css/sidebar.css
+++ b/5.26/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.27/css/sidebar.css
+++ b/5.27/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.28/css/sidebar.css
+++ b/5.28/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.29/css/sidebar.css
+++ b/5.29/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.3/css/sidebar.css
+++ b/5.3/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.30/css/sidebar.css
+++ b/5.30/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.31/css/sidebar.css
+++ b/5.31/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.32/css/sidebar.css
+++ b/5.32/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.33/css/sidebar.css
+++ b/5.33/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.34/css/sidebar.css
+++ b/5.34/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.35/css/sidebar.css
+++ b/5.35/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.36/css/sidebar.css
+++ b/5.36/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.37/css/sidebar.css
+++ b/5.37/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.38/css/sidebar.css
+++ b/5.38/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.4/css/sidebar.css
+++ b/5.4/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.5/css/sidebar.css
+++ b/5.5/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.6/css/sidebar.css
+++ b/5.6/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.7/css/sidebar.css
+++ b/5.7/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.8/css/sidebar.css
+++ b/5.8/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/5.9/css/sidebar.css
+++ b/5.9/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -289,7 +290,6 @@ span.sidebar-link.active a {
         display: none;
         height: auto!important;
         box-sizing: border-box;
-        max-height: calc(100vh - 2.7rem);
         overflow-y: auto;
         top: 100%;
         right: 0;

--- a/main/css/sidebar.css
+++ b/main/css/sidebar.css
@@ -272,6 +272,7 @@ span.sidebar-link.active a {
 }
 
 .archived-versions .nav-dropdown {
+    max-height: 20em;
     box-sizing: border-box;
     overflow-y: auto;
     top: 100%;
@@ -282,7 +283,6 @@ span.sidebar-link.active a {
     white-space: nowrap;
     margin: 0;
     top: 0;
-    max-height: 20em;
 }
 
 @media (min-width: 859px) {


### PR DESCRIPTION
apply the same style as #457 (shorter dropdown) to all the past versions

The new 'max-height' goes to the top because it's easier to do the search/replace