### PR TITLE
Apply goto-page onto the main version-switcher buttons

### DIFF
--- a/docs/js/versions.js
+++ b/docs/js/versions.js
@@ -55,10 +55,19 @@ function populateArchivedVersions() {
 }
 
 function gotoVersion(e) {
-  e.preventDefault();
-  const version = $(e.target).text();
-  const newUrl = window.location.href.replace(/(\/openhab-scripting\/)(?:\d+\.\d+|main)\//, `$1${version}/`);
-  window.location.href = newUrl;
+  // The target could be a sub element of the <a> tag, e.g. <small>
+  const target = e.target.tagName === 'A' ? e.target : e.target.closest('a');
+  if (target.classList.contains('current')) {
+    e.preventDefault();
+    return;
+  }
+  const version = target.pathname.split('/').filter(s => s).slice(-1)[0];
+  const versionRegex = new RegExp(`(?<=/openhab-jruby/)(\\d+\\.\\d+|main)(?=/)`);
+  const newUrl = window.location.href.replace(versionRegex, version);
+  if (newUrl !== window.location.href) {
+    e.preventDefault();
+    window.location.href = newUrl;
+  }
 }
 
 $(document).ready(function() {

--- a/lib/openhab/rspec/karaf.rb
+++ b/lib/openhab/rspec/karaf.rb
@@ -7,6 +7,7 @@ require "time"
 
 require_relative "jruby"
 require_relative "shell"
+require_relative "mocks/synchronous_executor"
 
 module OpenHAB
   module RSpec
@@ -291,7 +292,6 @@ module OpenHAB
             cfg.update(props)
           end
           wait_for_service("org.openhab.core.automation.RuleManager") do |re|
-            require_relative "mocks/synchronous_executor"
             # overwrite thCallbacks to one that will spy to remove threading
             field = re.class.java_class.declared_field :thCallbacks
             field.accessible = true
@@ -430,8 +430,6 @@ module OpenHAB
           end
 
           if bundle_name == "org.openhab.core"
-            require_relative "mocks/synchronous_executor"
-
             org.openhab.core.common.ThreadPoolManager.field_accessor :pools
             org.openhab.core.common.ThreadPoolManager.pools = Mocks::SynchronousExecutorMap.instance
           end

--- a/templates/default/layout/html/versions.erb
+++ b/templates/default/layout/html/versions.erb
@@ -1,7 +1,7 @@
 <div class="page-versions">
   <ul class="version-switcher">
-    <li><a href="/openhab-jruby/5.38" class="version-button stable">Stable <small>(5.38)</small></a></li>
-    <li><a href="/openhab-jruby/main" class="version-button main">Latest <small>(main)</small></a></li>
+    <li><a href="/openhab-jruby/5.38" class="version-button stable" onclick="gotoVersion(event)">Stable <small>(5.38)</small></a></li>
+    <li><a href="/openhab-jruby/main" class="version-button main" onclick="gotoVersion(event)">Latest <small>(main)</small></a></li>
   </ul>
   <div class="archived-versions">
     <div class="dropdown-wrapper">


### PR DESCRIPTION
Also includes a bug fix s/openhab-scripting/openhab-jruby/

Note, I had to move `require_relative "mocks/synchronous_executor"` to the top of the file due to the errors in https://github.com/openhab/openhab-jruby/actions/runs/14594673803/job/40939084574


