### PR TITLE
Add `OpenHAB::Core.user_data_folder`

### DIFF
--- a/lib/openhab/core.rb
+++ b/lib/openhab/core.rb
@@ -68,6 +68,14 @@ module OpenHAB
       end
 
       #
+      # @!attribute [r] user_data_folder
+      # @return [Pathname] The userdata folder path.
+      #
+      def user_data_folder
+        Pathname.new(org.openhab.core.OpenHAB.user_data_folder)
+      end
+
+      #
       # @!attribute [r] automation_manager
       # @return [org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager]
       #   The openHAB Automation manager.


### PR DESCRIPTION
should we call this `user_data_folder` matching the one in core?