### PR TITLE
Semantics tag lookup: prioritize ID over label or synonym

### DIFF
--- a/lib/openhab/core/items/semantics.rb
+++ b/lib/openhab/core/items/semantics.rb
@@ -212,8 +212,9 @@ module OpenHAB
             # Java21 added #first method, which overrides Ruby's #first.
             # It throws an error if the list is Empty instead of returning nil.
             # So we use #ruby_first to ensure we get Ruby's behaviour
-            tag_class = service.get_by_label_or_synonym(id, locale).ruby_first ||
-                        Provider.registry.get_tag_class_by_id(id)
+            tag_class = Provider.registry.get_tag_class_by_id(id) ||
+                        service.get_by_label_or_synonym(id, locale).ruby_first
+
             return unless tag_class
 
             Provider.registry.get(Provider.registry.class.build_id(tag_class))


### PR DESCRIPTION
The additions in the core semantic tags had some duplicates and inconsistencies in synonyms, as a result lookups resulted in wrong tags being found because we searched in synonyms and labels first.

One example is the tag `App`. The Tag `Application` (which is not the same as `App`) had `App` in its synonyms, causing `Semantics::App` to point to `Application` instead.

This PR makes sure we look up by ID first.

The conflicting synonyms need to be fixed in core too: https://github.com/openhab/openhab-core/pull/4885