### PR TITLE
check that an ItemChannelLinkProvider can even remove links for items

### DIFF
--- a/lib/openhab/core/items/registry.rb
+++ b/lib/openhab/core/items/registry.rb
@@ -79,7 +79,7 @@ module OpenHAB
           end
 
           Things::Links::Provider.registry.providers.grep(ManagedProvider).each do |managed_provider|
-            managed_provider.remove_links_for_item(item_name)
+            managed_provider.remove_links_for_item(item_name) if managed_provider.respond_to?(:remove_links_for_item)
           end
           provider.remove(item_name, recursive)
         end


### PR DESCRIPTION
org.openhab.core.thing.link.ManagedItemChannelLinkProvider and OpenHAB::Core::Items::Provider can, but
org.openhab.core.automation.module.script.providersupport.shared. ScriptedItemChannelLinkProvider cannot