### PR TITLE
publish docs sequentially to avoid concurrency issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,13 +79,13 @@ jobs:
       ref_name: main
       ref_type: branch
   publish_tag_docs:
-    needs: release
+    needs: publish_main_docs
     uses: ./.github/workflows/yardoc.yml
     with:
       ref_name: v${{needs.release.outputs.NEW_VERSION}}
       ref_type: tag
   publish_docs_versions:
-    needs: publish_main_docs
+    needs: publish_tag_docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
@@ -107,6 +107,6 @@ jobs:
           else
             git config --local user.name 'github-actions[bot]'
             git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
-            git commit -m "Update versions.js with new version v${{ env.NEW_VERSION }}"
+            git commit -m "Update versions.js with new version v${{needs.release.outputs.NEW_VERSION}}"
             git push
           fi

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Determine Destination Dir
         id: destination_dir
         run: ruby -e 'ref_name = "${{ inputs.ref_name || github.ref_name }}"; ref_name = ref_name[1..-1].split(".")[0..1].join(".") if "${{ inputs.ref_type || github.ref_type }}" == "tag"; puts "DESTINATION_DIR=#{ref_name}"' >> $GITHUB_OUTPUT
-      - name: Avoid race condition with push to main branch
-        if: ${{ (inputs.ref_type || github.ref_type) == 'tag' }}
-        run: sleep 15
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
The docs for 5.41 and 5.42 haven't been published successfully, e.g. https://github.com/openhab/openhab-jruby/actions/runs/17933055669/job/50993850891

Hopefully this solves the problem.