### PR TITLE
Fix `event` trigger when types are not specified.

### DIFF
--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -1804,6 +1804,7 @@ module OpenHAB
         #   end
         #
         def event(topic, source: nil, types: nil, attach: nil)
+          types ||= org.openhab.core.events.EventSubscriber::ALL_EVENT_TYPES
           types = types.join(",") if types.is_a?(Enumerable)
           trigger("core.GenericEventTrigger",
                   topic:,


### PR DESCRIPTION
The type must be a specific keyword to subscribe to all types, not an empty string (which is what `nil` was eventually becoming)