### PR TITLE
Fix item and thing builder update of existing object

### DIFF
--- a/lib/openhab/dsl/things/builder.rb
+++ b/lib/openhab/dsl/things/builder.rb
@@ -95,16 +95,13 @@ module OpenHAB
           builder.instance_eval(&block) if block
           thing = builder.build
 
-          if DSL.things.key?(thing.uid)
+          if (old_thing = DSL.things[thing.uid])
             raise ArgumentError, "Thing #{thing.uid} already exists" unless @update
+            raise FrozenError, "Thing #{thing.uid} is managed by #{thing.provider}" unless provider.get(thing.uid)
 
-            unless (old_thing = provider.get(thing.uid))
-              raise FrozenError, "Thing #{thing.uid} is managed by #{thing.provider}"
-            end
-
-            if thing.config_eql?(old_thing)
+            if thing.config_eql?(old_thing.__getobj__)
               logger.debug { "Not replacing existing thing #{thing.uid}" }
-              thing = old_thing
+              thing = old_thing.__getobj__
             else
               provider.update(thing)
             end


### PR DESCRIPTION
Fix #506

provider.get doesn't store/return the actual object, so we need to get the old item from the registry instead.

https://github.com/openhab/openhab-core/blob/aff119cd19f464d01e65cce57bd60f92ac631081/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java#L65