### PR TITLE
bypass version constraints for runtime openhab version gems

### DIFF
--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -336,7 +336,7 @@ namespace :openhab do
   task deploy: %i[download build] do |_task|
     mkdir_p gem_home
     gem_file = File.join(PACKAGE_DIR, "openhab-scripting-#{OpenHAB::DSL::VERSION}.gem")
-    fail_on_error("gem install #{gem_file} -i #{gem_home} --no-document")
+    fail_on_error("gem install #{gem_file} -i #{gem_home} --no-document --force")
   end
 
   desc "Clean up local gems"

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -5,6 +5,6 @@ require "cucumber/rake/task"
 desc "Run Cucumber Features"
 task :features, [:feature] => ["openhab:warmup", "openhab:deploy"] do |_, args|
   Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "--format pretty #{args[:feature]}"
+    t.cucumber_opts = ["--format", "pretty", args[:feature]].compact
   end
 end


### PR DESCRIPTION
Cucumber was failing to install gems that depend on our "dummy" openhab version gem created dynamically at runtime. Because these gems do not exist during CLI call, the dependency check fails.

This PR adds the `--force` flag to the `gem install` command
