### PR TITLE
add bigdecimal, csv, and irb to gemspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: steps.cache.outputs.cache-hit != 'true'
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          # Use JRuby for openHAB setup so it installs the correct version of the bigdecimal gem for JRuby
+          ruby-version: jruby-10.1.1.0
           bundler-cache: true
       - uses: actions/setup-java@v5
         if: steps.cache.outputs.cache-hit != 'true'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,10 @@ PATH
   remote: .
   specs:
     openhab-scripting (5.50.0)
+      bigdecimal (~> 4.0)
       bundler (>= 2.2, < 5.0)
+      csv (~> 3.0)
+      irb (~> 1.4)
       marcel (~> 1.0)
       method_source (~> 1.0)
       openhab (>= 5.0.0, < 5.4)

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -23,7 +23,10 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true"
   }
 
+  spec.add_dependency "bigdecimal", "~> 4.0"
   spec.add_dependency "bundler", ">= 2.2", "< 5.0"
+  spec.add_dependency "csv", "~> 3.0"
+  spec.add_dependency "irb", "~> 1.4"
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
   # ENV var *only* for use from CI for Cucumber


### PR DESCRIPTION
Without this, installations using Gemfile will generate an error that bigdecimal and csv are missing.  Running `jrubyscripting console` would also cause an error complaining about the irb gem.

The current workaround is that they must be added to user's Gemfile explicitly.