### PR TITLE
Support openHAB 5.3-SNAPSHOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
       openhab_matrix: |
-        ["5.0.3", "5.1.3", "5.2.0-SNAPSHOT"]
+        ["5.0.3", "5.1.4", "5.2.0", "5.3.0-SNAPSHOT"]
       snapshot_date: |
         ${{ steps.snapshot-date.outputs.SNAPSHOT_DATE }}
     steps:
@@ -89,9 +89,11 @@ jobs:
           - java_version: 21
             openhab_version: 5.0.3
           - java_version: 21
-            openhab_version: 5.1.3
+            openhab_version: 5.1.4
           - java_version: 21
-            openhab_version: 5.2.0-SNAPSHOT
+            openhab_version: 5.2.0
+          - java_version: 21
+            openhab_version: 5.3.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v6
       - name: Cache openHAB setup
@@ -138,10 +140,13 @@ jobs:
             openhab_version: 5.0.3
           - java_version: 21
             jruby_version: jruby-10.0.2.0
-            openhab_version: 5.1.3
+            openhab_version: 5.1.4
           - java_version: 21
             jruby_version: jruby-10.0.6.0
-            openhab_version: 5.2.0-SNAPSHOT
+            openhab_version: 5.2.0
+          - java_version: 21
+            jruby_version: jruby-10.0.6.0
+            openhab_version: 5.3.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -186,9 +191,11 @@ jobs:
           - java_version: 21
             openhab_version: 5.0.3
           - java_version: 21
-            openhab_version: 5.1.3
+            openhab_version: 5.1.4
           - java_version: 21
-            openhab_version: 5.2.0-SNAPSHOT
+            openhab_version: 5.2.0
+          - java_version: 21
+            openhab_version: 5.3.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
             jruby_version: jruby-10.0.2.0
             openhab_version: 5.1.3
           - java_version: 21
-            jruby_version: jruby-10.0.5.0
+            jruby_version: jruby-10.0.6.0
             openhab_version: 5.2.0-SNAPSHOT
     steps:
       - uses: actions/checkout@v6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       bundler (>= 2.2, < 5.0)
       marcel (~> 1.0)
       method_source (~> 1.0)
-      openhab (>= 5.0.0, < 5.3)
+      openhab (>= 5.0.0, < 5.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -257,6 +257,13 @@ module OpenHAB
           rs.register_tracker(org.openhab.core.service.ReadyService::ReadyTracker.impl { continue.call }, filter)
         end
 
+        # openHAB 5.2.0.M5+ can leave RuleEngineImpl.started false in the rspec
+        # harness even after the rule-engine startlevel marker is reached.
+        # Force it on so RuleEngineImpl.runRule won't drop triggered events.
+        rule_manager = OSGi.service("org.openhab.core.automation.RuleManager")
+        rule_manager.class.field_accessor :started
+        rule_manager.started = true unless rule_manager.started
+
         begin
           # load storage based type providers
           ast = org.openhab.core.thing.binding.AbstractStorageBasedTypeProvider

--- a/lib/openhab/rspec/mocks/synchronous_executor.rb
+++ b/lib/openhab/rspec/mocks/synchronous_executor.rb
@@ -26,15 +26,18 @@ module OpenHAB
         end
 
         def submit(runnable)
-          return super unless Thread.current == main_thread
+          if OpenHAB::Core.version < "5.1.0" # @deprecated OH5.1 remove the version guard
+            return super unless Thread.current == main_thread # rubocop:disable Style/SoleNestedConditional
+          end
 
-          runnable.respond_to?(:run) ? runnable.run : runnable.call
-
-          java.util.concurrent.CompletableFuture.completed_future(nil)
+          value = runnable.respond_to?(:run) ? runnable.run : runnable.call
+          java.util.concurrent.CompletableFuture.completed_future(value)
         end
 
         def execute(runnable)
-          return super unless Thread.current == main_thread
+          if OpenHAB::Core.version < "5.1.0" # @deprecated OH5.1 remove the version guard
+            return super unless Thread.current == main_thread # rubocop:disable Style/SoleNestedConditional
+          end
 
           runnable.run
         end

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
   # ENV var *only* for use from CI for Cucumber
-  spec.add_dependency "openhab", ">= 5.0.0", "< 5.3" unless ENV["OPENHAB_NO_RUNTIME_DEP"]
+  spec.add_dependency "openhab", ">= 5.0.0", "< 5.4" unless ENV["OPENHAB_NO_RUNTIME_DEP"]
 
   spec.files = Dir["{lib}/**/*"]
   spec.require_paths = ["lib"]

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -252,6 +252,7 @@ namespace :openhab do
 
   def openhab_env
     {
+      "CHECK_ROOT_INSTANCE_RUNNING" => "false",
       "LANG" => ENV.fetch("LANG", nil),
       "JAVA_HOME" => ENV.fetch("JAVA_HOME", nil),
       "KARAF_REDIRECT" => karaf_log,

--- a/rakelib/openhab.rake
+++ b/rakelib/openhab.rake
@@ -11,7 +11,7 @@ require "net/http"
 # Disabled due to part of buid / potentially refactor into classes
 # rubocop: disable Rake/MethodDefinitionInTask -- Legacy code
 namespace :openhab do
-  @openhab_version = ENV["OPENHAB_VERSION"] || "5.2.0-SNAPSHOT"
+  @openhab_version = ENV["OPENHAB_VERSION"] || "5.3.0-SNAPSHOT"
   @port_numbers = {
     ssh: { port: ENV["OPENHAB_SSH_PORT"] || 8101, config: "org.apache.karaf.shell:sshPort" },
     lsp: { port: ENV["OPENHAB_LSP_PORT"] || 5007, config: "org.openhab.lsp:port" }


### PR DESCRIPTION
This is split into two commits: one to make the spec work on 5.2.0-snapshot, and the other one to upgrade to jruby-10.0.6.0

Addon upgrade: https://github.com/openhab/openhab-addons/pull/20951