### PR TITLE
Fix intermittent spec failures due to Log4j buffering

### DIFF
--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -417,10 +417,23 @@ module OpenHAB
       #   end
       #
       def spec_log_lines
-        File.open(log_file, "rb") do |f|
-          f.seek(@log_index) if @log_index
-          f.read.split("\n")
+        lines = []
+
+        # Give the underlying Log4j file channel up to ~50ms to flush its buffer to disk
+        5.times do
+          lines = File.open(log_file, "rb") do |f|
+            f.seek(@log_index) if @log_index
+            f.read.split("\n")
+          end
+
+          # If we read lines, break early. If it's still empty, yield execution to the
+          # JVM thread scheduler so the file appender thread can finish flushing.
+          break unless lines.empty?
+
+          sleep 0.01
         end
+
+        lines
       end
 
       private


### PR DESCRIPTION
Introduce a brief polling retry loop in `spec_log_lines` to allow the Log4j file appender time to flush its buffer to disk.

When a spec writes to the log and immediately reads it, the asynchronous buffer can cause the file read to return empty. This retry strategy ensures the lines are present before checking expectations.

Example problem: https://github.com/openhab/openhab-jruby/actions/runs/29247335703/job/86817212738

