### PR TITLE
remove unused output in openhab-snapshot-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     outputs:
-      openhab_matrix: |
-        ["5.0.3", "5.1.4", "5.2.0", "5.3.0-SNAPSHOT"]
-      snapshot_date: |
+      date: |
         ${{ steps.snapshot-date.outputs.SNAPSHOT_DATE }}
     steps:
       - name: Calculate Date for Cache Key
@@ -101,7 +99,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: tmp/
-          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
+          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.date || '' }}-java-${{ matrix.java_version }}
       - uses: ruby/setup-ruby@v1
         if: steps.cache.outputs.cache-hit != 'true'
         with:
@@ -162,7 +160,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: tmp/
-          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
+          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.date || '' }}-java-${{ matrix.java_version }}
           fail-on-cache-miss: true
       - name: RSpec
         run: bin/rspec --format progress --format html --out rspec.html
@@ -211,7 +209,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: tmp/
-          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.snapshot_date || '' }}-java-${{ matrix.java_version }}
+          key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.date || '' }}-java-${{ matrix.java_version }}
           fail-on-cache-miss: true
       - name: Cucumber
         run: BUNDLE_FROZEN=false OPENHAB_NO_RUNTIME_DEP=1 bin/rake features


### PR DESCRIPTION
Otherwise we'd be updating it for no reason every time there's a new openhab version.

