### PR TITLE
Troubleshoot hanging rspec runs that caused job time outs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,14 +163,40 @@ jobs:
           key: openHAB-setup-2-${{ matrix.openhab_version }}${{ endsWith(matrix.openhab_version, 'SNAPSHOT') && needs.openhab-snapshot-date.outputs.date || '' }}-java-${{ matrix.java_version }}
           fail-on-cache-miss: true
       - name: RSpec
-        run: bin/rspec --format progress --format html --out rspec.html
+        run: |
+          set -euo pipefail
+          bin/rspec --format progress --format html --out rspec.html &
+          rspec_pid=$!
+          start_time=$(date +%s)
+
+          while kill -0 "$rspec_pid" 2>/dev/null; do
+            sleep 30
+            now=$(date +%s)
+            elapsed=$((now - start_time))
+            echo "[heartbeat] $(date -u +%FT%TZ) rspec still running (${elapsed}s elapsed)"
+
+            if [[ "$elapsed" -ge 330 ]]; then
+              echo "RSpec exceeded 330s; collecting thread dump before termination"
+              kill -QUIT "$rspec_pid" || true
+              sleep 5
+              kill -TERM "$rspec_pid" || true
+              sleep 20
+              kill -KILL "$rspec_pid" || true
+              wait "$rspec_pid" || true
+              exit 124
+            fi
+          done
+
+          wait "$rspec_pid"
         timeout-minutes: 6
       - name: Upload openHAB Logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: RSpec-logs-${{ matrix.openhab_version }}-${{ matrix.jruby_version }}-java-${{ matrix.java_version }}
-          path: tmp/openhab/userdata/logs
+          path: |
+            tmp/openhab/userdata/logs
+            tmp/karaf.log
           retention-days: 2
       - name: Upload RSpec results
         uses: actions/upload-artifact@v6

--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -364,10 +364,11 @@ module OpenHAB
       # @param [String] addon_id The addon id, such as "binding-mqtt"
       # @param [true,false] wait Wait until OSGi has confirmed the bundle is installed and running before returning.
       # @param [String,Array<String>] ready_markers Array of ready marker types to wait for.
+      # @param [Numeric] ready_timeout Max seconds to wait for ready markers.
       #   The addon's bundle id is used as the identifier.
       # @return [void]
       #
-      def install_addon(addon_id, wait: true, ready_markers: nil)
+      def install_addon(addon_id, wait: true, ready_markers: nil, ready_timeout: 30)
         service_filter = "(component.name=org.openhab.core.karafaddons)"
         addon_service = OSGi.service("org.openhab.core.addon.AddonService", filter: service_filter)
         addon_service.install(addon_id)
@@ -395,8 +396,19 @@ module OpenHAB
         end
 
         rs = OSGi.service("org.openhab.core.service.ReadyService")
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + ready_timeout
+
         loop do
-          break if ready_markers.all? { |rm| rs.ready?(rm) }
+          pending_markers = ready_markers.reject { |rm| rs.ready?(rm) }
+          break if pending_markers.empty?
+
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            pending_marker_text = pending_markers
+                                  .map { |rm| "#{rm.type}(#{rm.identifier})" }
+                                  .join(", ")
+            logger.warn("Timed out waiting for ready markers for #{addon_id}: #{pending_marker_text}")
+            raise "Timed out after #{ready_timeout}s waiting for ready markers for #{addon_id}: #{pending_marker_text}"
+          end
 
           sleep 0.25
         end

--- a/lib/openhab/rspec/helpers.rb
+++ b/lib/openhab/rspec/helpers.rb
@@ -364,20 +364,35 @@ module OpenHAB
       # @param [String] addon_id The addon id, such as "binding-mqtt"
       # @param [true,false] wait Wait until OSGi has confirmed the bundle is installed and running before returning.
       # @param [String,Array<String>] ready_markers Array of ready marker types to wait for.
+      # @param [Numeric] install_timeout Max seconds to wait for addon installation.
       # @param [Numeric] ready_timeout Max seconds to wait for ready markers.
       #   The addon's bundle id is used as the identifier.
       # @return [void]
       #
-      def install_addon(addon_id, wait: true, ready_markers: nil, ready_timeout: 30)
+      def install_addon(addon_id, wait: true, ready_markers: nil, install_timeout: 30, ready_timeout: 30)
         service_filter = "(component.name=org.openhab.core.karafaddons)"
         addon_service = OSGi.service("org.openhab.core.addon.AddonService", filter: service_filter)
         addon_service.install(addon_id)
         return unless wait
 
         addon = nil
+        install_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        install_deadline = install_start + install_timeout
+        next_install_log_at = install_start + 5
         loop do
           addon = addon_service.get_addon(addon_id, nil)
-          break if addon.installed?
+          break if addon&.installed?
+
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          if now >= next_install_log_at
+            elapsed = (now - install_start).round(1)
+            logger.warn("Still waiting for addon to install: #{addon_id} (elapsed=#{elapsed}s, timeout=#{install_timeout}s)") # rubocop:disable Layout/LineLength
+            next_install_log_at = now + 5
+          end
+
+          if now >= install_deadline
+            raise "Timed out after #{install_timeout}s waiting for addon installation: #{addon_id}"
+          end
 
           sleep 0.25
         end
@@ -396,16 +411,26 @@ module OpenHAB
         end
 
         rs = OSGi.service("org.openhab.core.service.ReadyService")
-        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + ready_timeout
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        deadline = start + ready_timeout
+        next_log_at = start + 5
 
         loop do
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           pending_markers = ready_markers.reject { |rm| rs.ready?(rm) }
           break if pending_markers.empty?
 
-          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-            pending_marker_text = pending_markers
-                                  .map { |rm| "#{rm.type}(#{rm.identifier})" }
-                                  .join(", ")
+          pending_marker_text = pending_markers
+                                .map { |rm| "#{rm.type}(#{rm.identifier})" }
+                                .join(", ")
+
+          if now >= next_log_at
+            elapsed = (now - start).round(1)
+            logger.warn("Still waiting for ready markers for #{addon_id} (elapsed=#{elapsed}s, timeout=#{ready_timeout}s): #{pending_marker_text}") # rubocop:disable Layout/LineLength
+            next_log_at = now + 5
+          end
+
+          if now >= deadline
             logger.warn("Timed out waiting for ready markers for #{addon_id}: #{pending_marker_text}")
             raise "Timed out after #{ready_timeout}s waiting for ready markers for #{addon_id}: #{pending_marker_text}"
           end

--- a/lib/openhab/rspec/karaf.rb
+++ b/lib/openhab/rspec/karaf.rb
@@ -382,7 +382,7 @@ module OpenHAB
           @thing_type_tracker.class.field_reader :openState
           org.openhab.core.config.core.xml.osgi.XmlDocumentBundleTracker::OpenState.field_reader :OPENED
           opened = org.openhab.core.config.core.xml.osgi.XmlDocumentBundleTracker::OpenState.OPENED
-          sleep until @thing_type_tracker.openState == opened
+          wait_until("thing type tracker open") { @thing_type_tracker.openState == opened }
           @bundle_context.bundles.each do |bundle|
             @thing_type_tracker.adding_bundle(bundle, nil)
           end
@@ -394,7 +394,7 @@ module OpenHAB
           @config_description_tracker.class.field_reader :openState
           org.openhab.core.config.core.xml.osgi.XmlDocumentBundleTracker::OpenState.field_reader :OPENED
           opened = org.openhab.core.config.core.xml.osgi.XmlDocumentBundleTracker::OpenState.OPENED
-          sleep until @config_description_tracker.openState == opened
+          wait_until("config description tracker open") { @config_description_tracker.openState == opened }
           @bundle_context.bundles.each do |bundle|
             @config_description_tracker.adding_bundle(bundle, nil)
           end
@@ -532,7 +532,7 @@ module OpenHAB
       end
 
       def wait_for_start
-        wait do |continue|
+        wait(timeout: 120, label: "all bundles to start") do |continue|
           @all_bundles_continue = continue
           next continue.call if all_bundles_started?
         end
@@ -557,10 +557,11 @@ module OpenHAB
           bundle.fragment?
       end
 
-      def wait(timeout: 30)
+      def wait(timeout: 30, label: nil)
         mutex = Mutex.new
         cond = ConditionVariable.new
         skip_wait = false
+        timed_out = false
 
         continue = lambda do
           # if continue was called synchronously, we can just return
@@ -570,8 +571,40 @@ module OpenHAB
         end
         mutex.synchronize do
           yield continue
-          cond.wait(mutex, timeout) unless skip_wait
+          timed_out = !cond.wait(mutex, timeout) unless skip_wait
         end
+
+        return unless timed_out
+
+        detail = label ? " while waiting for #{label}" : ""
+        raise "Timed out after #{timeout}s#{detail}. #{bundle_state_summary}"
+      end
+
+      def wait_until(label, timeout: 30, interval: 0.1)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        until yield
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+            raise "Timed out after #{timeout}s while waiting for #{label}. #{bundle_state_summary}"
+          end
+
+          sleep interval
+        end
+      end
+
+      def bundle_state_summary
+        return "Bundle state unavailable" unless @bundle_context
+
+        bundle_counts = @bundle_context.bundles.each_with_object(Hash.new(0)) do |bundle, counts|
+          counts[bundle.state] += 1
+        end
+
+        active = org.osgi.framework.Bundle::ACTIVE
+        resolved = org.osgi.framework.Bundle::RESOLVED
+        starting = org.osgi.framework.Bundle::STARTING
+        installed = org.osgi.framework.Bundle::INSTALLED
+
+        "Bundles: active=#{bundle_counts[active]}, resolved=#{bundle_counts[resolved]}, " \
+          "starting=#{bundle_counts[starting]}, installed=#{bundle_counts[installed]}, total=#{@bundle_context.bundles.length}" # rubocop:disable Layout/LineLength
       end
 
       def link_osgi


### PR DESCRIPTION
Copilot assisted in this.

The branch now fails fast on bootstrap hangs and emits diagnostics before the GitHub runner kills the job.

Changes made

Bounded previously unbounded Karaf waits
Replaced infinite tracker waits with timeout-based waits in karaf.rb:385 and karaf.rb:397.
Added timeout helper methods that raise with context instead of blocking forever in karaf.rb:583.
Startup wait now fails with context instead of silently continuing
wait_for_start now uses an explicit timeout and label in karaf.rb:534.
Core wait method now raises on timeout in karaf.rb:560.
Added bundle state summary to timeout errors in karaf.rb:594.
CI RSpec step now gives heartbeat and thread dump on long hang
Wrapped RSpec run with heartbeat output every 30s in ci.yml:165.
If elapsed reaches 330s, sends SIGQUIT (thread dump), then TERM/KILL, exits 124 in ci.yml:178.
Added karaf.log to failure artifact upload in ci.yml:197.