### PR TITLE
Install openhab-core-model-yaml in the rspec Karaf instance

### DIFF
--- a/lib/openhab/rspec/karaf.rb
+++ b/lib/openhab/rspec/karaf.rb
@@ -366,6 +366,7 @@ module OpenHAB
         "org.openhab.core.model.rule.runtime" => nil,
         "org.openhab.core.model.rule" => nil,
         "org.openhab.core.model.sitemap.runtime" => nil,
+        "org.openhab.core.ui" => nil,
         "org.openhab.core.voice" => nil
       }.freeze
       private_constant :BLOCKED_COMPONENTS
@@ -805,11 +806,14 @@ module OpenHAB
                     <f:feature>openhab-core-model-script</f:feature>
                     <f:feature>openhab-core-model-sitemap</f:feature>
                     <f:feature>openhab-core-model-thing</f:feature>
+                    <f:feature>openhab-core-model-yaml</f:feature>
                     <f:feature>openhab-core-storage-json</f:feature>
                     <f:feature>openhab-core-ui-icon</f:feature>
                     <f:feature>openhab-transport-http</f:feature>
                     <f:feature prerequisite="true">wrapper</f:feature>
                     <f:bundle>mvn:org.openhab.core.bundles/org.openhab.core.karaf/#{version}</f:bundle>
+                    <!-- openhab-core-model-yaml imports org.openhab.core.ui.components since OH 5.2 -->
+                    <f:bundle>mvn:org.openhab.core.bundles/org.openhab.core.ui/#{version}</f:bundle>
                   </feature>
                 </replacement>
               </featureReplacements>


### PR DESCRIPTION
> This PR contains AI-generated code and/or description. I have reviewed the implementation, verified the intent, and take full responsibility as the author.

The trimmed `openhab-runtime-base` replacement omitted the YAML model feature, so `things/*.yaml` files never loaded in specs.

Since openHAB 5.2, `org.openhab.core.model.yaml` has a mandatory package import on `org.openhab.core.ui.components`, so `org.openhab.core.ui` has to be installed for the feature to resolve — `BLOCKED_COMPONENTS` keeps it from ever starting. If you'd rather not carry a UI bundle here at all, the alternative is upstream: splitting the UI-component handling out of the YAML model bundle, or making that import optional.