### PR TITLE
Fix Month-range comparisons for `Time` and `ZonedDateTime`

### DIFF
--- a/lib/openhab/core_ext/java/zoned_date_time.rb
+++ b/lib/openhab/core_ext/java/zoned_date_time.rb
@@ -229,10 +229,12 @@ module OpenHAB
         def <=>(other)
           # compare instants, otherwise it will differ by timezone, which we don't want
           # (use eql? if you care about that)
-          if other.respond_to?(:to_zoned_date_time)
-            to_instant.compare_to(other.to_zoned_date_time(self).to_instant)
+          if other.is_a?(self.class)
+            to_instant.compare_to(other.to_instant)
           elsif other.respond_to?(:coerce) && (lhs, rhs = other.coerce(self))
             lhs <=> rhs
+          elsif other.respond_to?(:to_zoned_date_time)
+            to_instant.compare_to(other.to_zoned_date_time(self).to_instant)
           end
         end
 

--- a/lib/openhab/core_ext/ruby/time.rb
+++ b/lib/openhab/core_ext/ruby/time.rb
@@ -68,6 +68,28 @@ class Time
   alias_method :minus_without_temporal, :-
   alias_method :-, :minus_with_temporal
 
+  # @!parse
+  #   # Extends {#<=>} to allow comparisons via #coerce with time-like objects
+  #   # such as Month and MonthDay.
+  #   # @return [Integer, nil]
+  #   def compare_with_coercion(other)
+  #   end
+  #   alias_method :<=>, :compare_with_coercion
+
+  # @!visibility private
+  # @return [Integer, nil]
+  def oh_compare_with_coercion(other)
+    return oh_compare_without_coercion(other) if other.is_a?(self.class)
+
+    if other.respond_to?(:coerce) && (lhs, rhs = other.coerce(self))
+      return lhs <=> rhs
+    end
+
+    oh_compare_without_coercion(other)
+  end
+  alias_method :oh_compare_without_coercion, :<=>
+  alias_method :<=>, :oh_compare_with_coercion
+
   # @return [LocalDate]
   def to_local_date(_context = nil)
     java.time.LocalDate.of(year, month, day)

--- a/spec/openhab/core_ext/between_spec.rb
+++ b/spec/openhab/core_ext/between_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenHAB::CoreExt::Between do
+  around do |example|
+    Timecop.freeze
+    example.run
+  ensure
+    Timecop.return
+  end
+
+  describe "#between?" do
+    it "raises an ArgumentError when given only one argument that isn't a Range" do
+      now = ZonedDateTime.now
+      expect { now.between?(now) }.to raise_error(ArgumentError, /Expecting a range/)
+    end
+  end
+end

--- a/spec/openhab/core_ext/java/zoned_date_time_spec.rb
+++ b/spec/openhab/core_ext/java/zoned_date_time_spec.rb
@@ -254,5 +254,17 @@ RSpec.describe java.time.ZonedDateTime do
       expect(zdt.between?((zdt - 5.days)...zdt)).to be false
       expect(zdt.between?(zdt..)).to be true
     end
+
+    context "when compared against Month ranges" do
+      let(:august_zdt) { described_class.parse("2022-08-15T13:37:00+00:00") }
+
+      it "includes dates that fall in the range end month" do
+        expect(august_zdt.between?(Month::JUNE..Month::AUGUST)).to be true
+      end
+
+      it "compares against a Month endpoint by month precision" do
+        expect(august_zdt <= Month::AUGUST).to be true
+      end
+    end
   end
 end

--- a/spec/openhab/core_ext/ruby/time_spec.rb
+++ b/spec/openhab/core_ext/ruby/time_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe Time do
       expect(time.between?((time - 5)...time)).to be false
       expect(time.between?(time..)).to be true
     end
+
+    context "when compared against Month ranges" do
+      let(:august_time) { described_class.new(2022, 8, 15, 13, 37, 0, "+00:00") }
+
+      it "includes dates that fall in the range end month" do
+        expect(august_time.between?(Month::JUNE..Month::AUGUST)).to be true
+      end
+
+      it "compares against a Month endpoint by month precision" do
+        expect(august_time <= Month::AUGUST).to be true
+      end
+    end
   end
 
   describe "#to_instant" do

--- a/spec/openhab/core_ext/time_predicates_spec.rb
+++ b/spec/openhab/core_ext/time_predicates_spec.rb
@@ -57,11 +57,4 @@ RSpec.describe OpenHAB::CoreExt::TimePredicates do
       end
     end
   end
-
-  describe "#between?" do
-    it "raises an ArgumentError when given only one argument that isn't a Range" do
-      now = ZonedDateTime.now
-      expect { now.between?(now) }.to raise_error(ArgumentError, /Expecting a range/)
-    end
-  end
 end


### PR DESCRIPTION
Prefer cross-type coercion when comparing time-like objects so `Month`/`MonthDay` endpoints are compared by precision rather than being treated as start-of-period instants. This prevents expressions like `Time.now.between?(Month::JUNE..Month::AUGUST)` from incorrectly returning false in August.

