### PR TITLE
Remove irb from gemspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           files: .
           config_file: .markdownlint.yaml
+          ignore_files: CHANGELOG.md
 
   yard-coverage:
     runs-on: ubuntu-latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ PATH
       bigdecimal (~> 4.0)
       bundler (>= 2.2, < 5.0)
       csv (~> 3.0)
-      irb (~> 1.4)
       marcel (~> 1.0)
       method_source (~> 1.0)
       openhab (>= 5.0.0, < 5.4)

--- a/openhab-scripting.gemspec
+++ b/openhab-scripting.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bigdecimal", "~> 4.0"
   spec.add_dependency "bundler", ">= 2.2", "< 5.0"
   spec.add_dependency "csv", "~> 3.0"
-  spec.add_dependency "irb", "~> 1.4"
   spec.add_dependency "marcel", "~> 1.0"
   spec.add_dependency "method_source", "~> 1.0"
   # ENV var *only* for use from CI for Cucumber


### PR DESCRIPTION
Having irb as a dependency causes bundler to try to install newer version of irb which fails on docker due to its transitive dependency to prism. Prism can't install/build in a standard openhab docker environment.

As of JRuby 10.1.1.0 irb is still bundled, so not having the dependency here makes the addon's default gem installation to work fine.

When using Gemfile, one must explicitly add `gem "irb"` to the Gemfile to run the karaf jrubyscripting console (which is how it was before we added the irb dependency to gemspec).


Found the past attempts: #438, #415, #422 (issue caused by psych back then, it's prism now)
