### PR TITLE
Add file path and line number to rule source metadata

### DIFF
--- a/lib/openhab/core_ext/gems/method_source.rb
+++ b/lib/openhab/core_ext/gems/method_source.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "method_source"
+
+module OpenHAB
+  module CoreExt
+    #
+    # Patches to gems
+    #
+    module Gems
+      #
+      # Patches to the method_source gem
+      #
+      module MethodSourceScriptPatch
+        #
+        # Read source lines from openHAB UI scripts when target file is "<script>".
+        #
+        def lines_for(file_name, line = nil)
+          if file_name == "<script>" && (uid = $ctx&.[]("ruleUID"))
+            script = OpenHAB::DSL.rules[uid]&.actions&.first&.configuration&.[]("script")
+            return script.lines if script
+          end
+
+          super
+        end
+      end
+    end
+  end
+end
+
+MethodSource.singleton_class.prepend(OpenHAB::CoreExt::Gems::MethodSourceScriptPatch)

--- a/lib/openhab/dsl.rb
+++ b/lib/openhab/dsl.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "java"
-require "method_source"
 
 require "bundler/inline"
 

--- a/lib/openhab/dsl/rules/builder.rb
+++ b/lib/openhab/dsl/rules/builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "forwardable"
+require "openhab/core_ext/gems/method_source"
 
 Dir[File.expand_path("**/*.rb", __dir__)].reject { |f| f == __FILE__ }.each do |f|
   require f
@@ -72,7 +73,7 @@ module OpenHAB
           raise ArgumentError, "Block is required" unless block
 
           id ||= inferred_id = NameInference.infer_rule_id_from_block(block)
-          script ||= block.source rescue nil # rubocop:disable Style/RescueModifier
+          script ||= script_source(block)
 
           builder = nil
 
@@ -155,7 +156,7 @@ module OpenHAB
           inferred_id = nil # rubocop:disable Lint/UselessAssignment -- it is used below
           id ||= inferred_id = NameInference.infer_rule_id_from_block(block)
           name ||= id
-          script ||= block.source rescue nil # rubocop:disable Style/RescueModifier
+          script ||= script_source(block)
 
           if replace
             logger.debug { "Removing existing rule '#{id}'." } if DSL.rules.remove(id)
@@ -203,7 +204,7 @@ module OpenHAB
           inferred_id = nil # rubocop:disable Lint/UselessAssignment
           id ||= inferred_id = NameInference.infer_rule_id_from_block(block)
           name ||= id
-          script ||= block.source rescue nil # rubocop:disable Style/RescueModifier
+          script ||= script_source(block)
 
           if replace
             logger.debug { "Removing existing rule '#{id}'." } if DSL.rules.remove(id)
@@ -224,6 +225,26 @@ module OpenHAB
             logger.trace { builder.inspect }
             builder.build(provider, script)
           end
+        end
+
+        private
+
+        def script_source(block)
+          file, line = block.source_location
+          return unless line
+
+          location = if file == "<script>"
+                       "script:#{$ctx&.[]("ruleUID")}"
+                     else
+                       Pathname.new(file).relative_path_from(OpenHAB::Core.config_folder) rescue file # rubocop:disable Style/RescueModifier
+                     end
+
+          comment = block.comment&.strip rescue nil # rubocop:disable Style/RescueModifier
+          comment = nil if comment&.empty?
+
+          ["# Source: #{location}:#{line}", comment, block.source].compact.join("\n")
+        rescue
+          nil
         end
       end
 


### PR DESCRIPTION
Add file path and line number to rule source metadata

Include the file location (# path/to/file.rb:line) and preceding block
comments at the beginning of rule source metadata.

- Prepend location header and block comments before rule definitions
- Strip empty or whitespace-only comments to avoid extra blank lines
- Patch MethodSource to safely handle UI scripts with "<script>" source locations

Previously, access to `block.source` raised an exception when the file path is `<script>` (rescued to nil).

I tried writing a UI script that creates a rule that creates a rule:

<img width="523" height="560" alt="image" src="https://github.com/user-attachments/assets/2b246e2b-1d15-4b2e-9602-443a52f9a8f5" />

when ran, it created AAA TOP2 rule

<img width="499" height="370" alt="image" src="https://github.com/user-attachments/assets/9c6bd4c9-2cfc-45c4-a1d0-0ce4f1245f48" />

and when this rule runs, it creates BBB

<img width="500" height="268" alt="image" src="https://github.com/user-attachments/assets/d45f0148-4c96-4cb3-a3e2-7e57b04956f5" />

---

Lastly, for plain file-based rules:

<img width="623" height="269" alt="image" src="https://github.com/user-attachments/assets/168307e8-9435-4739-93c3-1f9153ffaa26" />
